### PR TITLE
feat: read stash-box endpoint config from Stash API

### DIFF
--- a/api/settings_router.py
+++ b/api/settings_router.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 
 from hardware import get_hardware_profile
 from settings import get_settings_manager, SETTING_DEFS
+from stashbox_connection_manager import get_connection_manager
 
 router = APIRouter(tags=["settings"])
 
@@ -147,3 +148,20 @@ async def get_system_info():
             "summary": profile.summary(),
         },
     }
+
+
+# ==================== StashBox connections ====================
+
+@router.get("/system/stashbox-connections")
+async def get_stashbox_connections():
+    """List all stash-box endpoints discovered from Stash's configuration."""
+    mgr = get_connection_manager()
+    return {"connections": mgr.get_connections()}
+
+
+@router.post("/system/refresh-stashbox-config")
+async def refresh_stashbox_config():
+    """Re-read stash-box endpoint config from Stash without restarting."""
+    mgr = get_connection_manager()
+    count = await mgr.refresh()
+    return {"endpoints_loaded": count, "connections": mgr.get_connections()}

--- a/api/stashbox_connection_manager.py
+++ b/api/stashbox_connection_manager.py
@@ -1,0 +1,179 @@
+"""StashBox Connection Manager.
+
+Reads stash-box endpoint configuration from Stash's GraphQL API and caches
+it in memory. Replaces the previous approach of hardcoded endpoint URLs and
+env var API keys with auto-discovery from whatever the user has configured
+in Stash's Settings > Metadata Providers.
+
+Usage:
+    # At startup
+    mgr = StashBoxConnectionManager(stash_url, stash_api_key)
+    await mgr.load()
+
+    # Get a client for an endpoint
+    client = mgr.get_client("stashdb.org")
+    client = mgr.get_client("https://stashdb.org/graphql")
+
+    # List configured endpoints
+    connections = mgr.get_connections()
+
+    # Refresh from Stash
+    await mgr.refresh()
+"""
+
+import logging
+from typing import Optional
+
+from stashbox_client import StashBoxClient
+
+logger = logging.getLogger(__name__)
+
+
+class StashBoxConnection:
+    """A single stash-box endpoint connection with its config."""
+
+    __slots__ = ("endpoint", "api_key", "name")
+
+    def __init__(self, endpoint: str, api_key: str, name: str):
+        self.endpoint = endpoint
+        self.api_key = api_key
+        self.name = name
+
+    @property
+    def domain(self) -> str:
+        """Extract domain from endpoint URL (e.g. 'stashdb.org' from 'https://stashdb.org/graphql')."""
+        return self.endpoint.replace("https://", "").replace("http://", "").replace("/graphql", "").rstrip("/")
+
+    def to_dict(self) -> dict:
+        return {
+            "endpoint": self.endpoint,
+            "name": self.name,
+            "domain": self.domain,
+        }
+
+
+class StashBoxConnectionManager:
+    """Manages stash-box endpoint connections read from Stash's configuration.
+
+    Provides client creation, lookup by domain or URL, and config refresh.
+    """
+
+    def __init__(self, stash_url: str, stash_api_key: str):
+        self._stash_url = stash_url
+        self._stash_api_key = stash_api_key
+        self._connections: list[StashBoxConnection] = []
+        self._clients: dict[str, StashBoxClient] = {}
+        self._loaded = False
+
+    @property
+    def loaded(self) -> bool:
+        return self._loaded
+
+    async def load(self) -> int:
+        """Load stash-box connections from Stash's configuration.
+
+        Returns the number of endpoints discovered.
+        """
+        from stash_client_unified import StashClientUnified
+
+        stash = StashClientUnified(self._stash_url, self._stash_api_key)
+        raw_connections = await stash.get_stashbox_connections()
+
+        self._connections = []
+        self._clients = {}
+
+        for conn in raw_connections:
+            endpoint = conn.get("endpoint", "")
+            api_key = conn.get("api_key", "")
+            name = conn.get("name", "")
+            if not endpoint:
+                continue
+            self._connections.append(StashBoxConnection(endpoint, api_key, name))
+
+        self._loaded = True
+
+        logger.warning(
+            f"Loaded {len(self._connections)} stash-box endpoint(s) from Stash: "
+            f"{', '.join(c.domain for c in self._connections)}"
+        )
+        return len(self._connections)
+
+    async def refresh(self) -> int:
+        """Re-read stash-box config from Stash. Returns endpoint count."""
+        return await self.load()
+
+    def get_connections(self) -> list[dict]:
+        """Return all configured connections as dicts (safe for API responses)."""
+        return [c.to_dict() for c in self._connections]
+
+    def _find_connection(self, endpoint_key: str) -> Optional[StashBoxConnection]:
+        """Find a connection by domain name or full URL.
+
+        Args:
+            endpoint_key: Either a domain like "stashdb.org" or a full URL
+                          like "https://stashdb.org/graphql"
+        """
+        for conn in self._connections:
+            if conn.domain == endpoint_key or conn.endpoint == endpoint_key:
+                return conn
+        return None
+
+    def get_client(self, endpoint_key: str) -> Optional[StashBoxClient]:
+        """Get or create a StashBoxClient for the given endpoint.
+
+        Args:
+            endpoint_key: Domain (e.g. "stashdb.org") or full URL.
+
+        Returns:
+            StashBoxClient if the endpoint is configured with an API key, None otherwise.
+        """
+        conn = self._find_connection(endpoint_key)
+        if not conn:
+            return None
+        if not conn.api_key:
+            return None
+
+        if conn.endpoint not in self._clients:
+            self._clients[conn.endpoint] = StashBoxClient(conn.endpoint, conn.api_key)
+
+        return self._clients[conn.endpoint]
+
+    def get_endpoint_url(self, endpoint_key: str) -> Optional[str]:
+        """Get the full endpoint URL for a domain or URL key.
+
+        Args:
+            endpoint_key: Domain (e.g. "stashdb.org") or full URL.
+
+        Returns:
+            The full GraphQL endpoint URL, or None if not configured.
+        """
+        conn = self._find_connection(endpoint_key)
+        return conn.endpoint if conn else None
+
+
+# Module-level singleton
+_manager: Optional[StashBoxConnectionManager] = None
+
+
+async def init_connection_manager(stash_url: str, stash_api_key: str) -> StashBoxConnectionManager:
+    """Initialize the global connection manager. Called once at startup."""
+    global _manager
+    _manager = StashBoxConnectionManager(stash_url, stash_api_key)
+    await _manager.load()
+    return _manager
+
+
+def get_connection_manager() -> StashBoxConnectionManager:
+    """Get the global connection manager. Must be called after init."""
+    if _manager is None:
+        raise RuntimeError(
+            "StashBoxConnectionManager not initialized. "
+            "Call init_connection_manager() during startup."
+        )
+    return _manager
+
+
+def set_connection_manager(mgr: StashBoxConnectionManager):
+    """Set the global connection manager (for testing)."""
+    global _manager
+    _manager = mgr

--- a/api/stashbox_router.py
+++ b/api/stashbox_router.py
@@ -11,7 +11,7 @@ from typing import Optional
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
-from stashbox_utils import _get_stashbox_client, ENDPOINT_URLS
+from stashbox_utils import _get_stashbox_client, _get_endpoint_url
 
 logger = logging.getLogger(__name__)
 
@@ -181,7 +181,9 @@ async def get_stashbox_performer(endpoint: str, stashdb_id: str):
     if not performer:
         raise HTTPException(status_code=404, detail="Performer not found on StashBox")
 
-    endpoint_url = ENDPOINT_URLS[endpoint]
+    endpoint_url = _get_endpoint_url(endpoint)
+    if not endpoint_url:
+        raise HTTPException(status_code=400, detail=f"Unknown endpoint: {endpoint}")
     return _map_stashbox_to_stash(performer, endpoint_url, stashdb_id)
 
 
@@ -225,7 +227,9 @@ async def create_performer_from_stashbox(request: CreatePerformerRequest):
     if not performer:
         raise HTTPException(status_code=404, detail="Performer not found on StashBox")
 
-    endpoint_url = ENDPOINT_URLS[request.endpoint]
+    endpoint_url = _get_endpoint_url(request.endpoint)
+    if not endpoint_url:
+        raise HTTPException(status_code=400, detail=f"Unknown endpoint: {request.endpoint}")
     mapped = _map_stashbox_to_stash(performer, endpoint_url, request.stashdb_id)
 
     # 2. Create performer in Stash

--- a/api/stashbox_utils.py
+++ b/api/stashbox_utils.py
@@ -1,52 +1,34 @@
 """Shared StashBox client utilities.
 
-Provides lazy client creation and endpoint extraction used by both
+Provides client creation and endpoint extraction used by both
 the identification and stashbox routers.
+
+Clients are sourced from the StashBoxConnectionManager which reads
+endpoint config from Stash's settings API (auto-discovery).
 """
 
-import os
 from typing import Optional
 
 from stashbox_client import StashBoxClient
-
-# StashBox endpoint configuration
-ENDPOINT_URLS = {
-    "stashdb.org": "https://stashdb.org/graphql",
-    "fansdb.cc": "https://fansdb.cc/graphql",
-    "theporndb.net": "https://theporndb.net/graphql",
-    "pmvstash.org": "https://pmvstash.org/graphql",
-    "javstash.org": "https://javstash.org/graphql",
-}
-
-ENDPOINT_API_KEY_ENVS = {
-    "stashdb.org": "STASHDB_API_KEY",
-    "fansdb.cc": "FANSDB_API_KEY",
-    "theporndb.net": "THEPORNDB_API_KEY",
-    "pmvstash.org": "PMVSTASH_API_KEY",
-    "javstash.org": "JAVSTASH_API_KEY",
-}
-
-# Lazily initialized StashBox clients
-_stashbox_clients: dict[str, StashBoxClient] = {}
+from stashbox_connection_manager import get_connection_manager
 
 
 def _get_stashbox_client(endpoint_domain: str) -> Optional[StashBoxClient]:
-    """Get or create a StashBox client for the given endpoint domain."""
-    if endpoint_domain in _stashbox_clients:
-        return _stashbox_clients[endpoint_domain]
+    """Get a StashBox client for the given endpoint domain or URL.
 
-    url = ENDPOINT_URLS.get(endpoint_domain)
-    env_key = ENDPOINT_API_KEY_ENVS.get(endpoint_domain)
-    if not url or not env_key:
-        return None
+    Reads from the StashBoxConnectionManager (backed by Stash config).
+    """
+    mgr = get_connection_manager()
+    return mgr.get_client(endpoint_domain)
 
-    api_key = os.environ.get(env_key, "")
-    if not api_key:
-        return None
 
-    client = StashBoxClient(url, api_key)
-    _stashbox_clients[endpoint_domain] = client
-    return client
+def _get_endpoint_url(endpoint_domain: str) -> Optional[str]:
+    """Get the full endpoint URL for a domain.
+
+    Reads from the StashBoxConnectionManager (backed by Stash config).
+    """
+    mgr = get_connection_manager()
+    return mgr.get_endpoint_url(endpoint_domain)
 
 
 def _extract_endpoint(universal_id: str | None) -> str | None:

--- a/api/tests/test_stashbox_connection_manager.py
+++ b/api/tests/test_stashbox_connection_manager.py
@@ -1,0 +1,316 @@
+"""Tests for StashBoxConnectionManager — reads stash-box config from Stash."""
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from stashbox_connection_manager import (
+    StashBoxConnection,
+    StashBoxConnectionManager,
+    get_connection_manager,
+    set_connection_manager,
+)
+
+
+# ==================== StashBoxConnection ====================
+
+
+class TestStashBoxConnection:
+    """Tests for the StashBoxConnection data class."""
+
+    def test_domain_extraction(self):
+        conn = StashBoxConnection("https://stashdb.org/graphql", "key", "StashDB")
+        assert conn.domain == "stashdb.org"
+
+    def test_domain_extraction_http(self):
+        conn = StashBoxConnection("http://localhost:9999/graphql", "key", "Local")
+        assert conn.domain == "localhost:9999"
+
+    def test_domain_extraction_no_graphql(self):
+        conn = StashBoxConnection("https://custom.example.com", "key", "Custom")
+        assert conn.domain == "custom.example.com"
+
+    def test_to_dict(self):
+        conn = StashBoxConnection("https://fansdb.cc/graphql", "key", "FansDB")
+        d = conn.to_dict()
+        assert d == {
+            "endpoint": "https://fansdb.cc/graphql",
+            "name": "FansDB",
+            "domain": "fansdb.cc",
+        }
+        # api_key should NOT be in the dict (security)
+        assert "api_key" not in d
+
+
+# ==================== StashBoxConnectionManager ====================
+
+
+class TestStashBoxConnectionManager:
+    """Tests for the connection manager."""
+
+    def _make_manager(self):
+        return StashBoxConnectionManager("http://stash:9999", "test-key")
+
+    @pytest.mark.asyncio
+    async def test_load_parses_connections(self):
+        mgr = self._make_manager()
+
+        mock_stash = AsyncMock()
+        mock_stash.get_stashbox_connections.return_value = [
+            {"endpoint": "https://stashdb.org/graphql", "api_key": "key1", "name": "StashDB"},
+            {"endpoint": "https://fansdb.cc/graphql", "api_key": "key2", "name": "FansDB"},
+        ]
+
+        with patch("stash_client_unified.StashClientUnified", return_value=mock_stash):
+            count = await mgr.load()
+
+        assert count == 2
+        assert mgr.loaded is True
+        connections = mgr.get_connections()
+        assert len(connections) == 2
+        assert connections[0]["domain"] == "stashdb.org"
+        assert connections[1]["domain"] == "fansdb.cc"
+
+    @pytest.mark.asyncio
+    async def test_load_skips_empty_endpoints(self):
+        mgr = self._make_manager()
+
+        mock_stash = AsyncMock()
+        mock_stash.get_stashbox_connections.return_value = [
+            {"endpoint": "https://stashdb.org/graphql", "api_key": "key1", "name": "StashDB"},
+            {"endpoint": "", "api_key": "key2", "name": "Empty"},
+        ]
+
+        with patch("stash_client_unified.StashClientUnified", return_value=mock_stash):
+            count = await mgr.load()
+
+        assert count == 1
+
+    @pytest.mark.asyncio
+    async def test_get_client_returns_client_for_configured_endpoint(self):
+        mgr = self._make_manager()
+
+        mock_stash = AsyncMock()
+        mock_stash.get_stashbox_connections.return_value = [
+            {"endpoint": "https://stashdb.org/graphql", "api_key": "key1", "name": "StashDB"},
+        ]
+
+        with patch("stash_client_unified.StashClientUnified", return_value=mock_stash):
+            await mgr.load()
+
+        client = mgr.get_client("stashdb.org")
+        assert client is not None
+        assert client.endpoint == "https://stashdb.org/graphql"
+        assert client.headers["ApiKey"] == "key1"
+
+    @pytest.mark.asyncio
+    async def test_get_client_by_full_url(self):
+        mgr = self._make_manager()
+
+        mock_stash = AsyncMock()
+        mock_stash.get_stashbox_connections.return_value = [
+            {"endpoint": "https://stashdb.org/graphql", "api_key": "key1", "name": "StashDB"},
+        ]
+
+        with patch("stash_client_unified.StashClientUnified", return_value=mock_stash):
+            await mgr.load()
+
+        client = mgr.get_client("https://stashdb.org/graphql")
+        assert client is not None
+        assert client.endpoint == "https://stashdb.org/graphql"
+
+    @pytest.mark.asyncio
+    async def test_get_client_returns_none_for_unknown_endpoint(self):
+        mgr = self._make_manager()
+
+        mock_stash = AsyncMock()
+        mock_stash.get_stashbox_connections.return_value = [
+            {"endpoint": "https://stashdb.org/graphql", "api_key": "key1", "name": "StashDB"},
+        ]
+
+        with patch("stash_client_unified.StashClientUnified", return_value=mock_stash):
+            await mgr.load()
+
+        client = mgr.get_client("unknown.org")
+        assert client is None
+
+    @pytest.mark.asyncio
+    async def test_get_client_returns_none_when_no_api_key(self):
+        mgr = self._make_manager()
+
+        mock_stash = AsyncMock()
+        mock_stash.get_stashbox_connections.return_value = [
+            {"endpoint": "https://stashdb.org/graphql", "api_key": "", "name": "StashDB"},
+        ]
+
+        with patch("stash_client_unified.StashClientUnified", return_value=mock_stash):
+            await mgr.load()
+
+        client = mgr.get_client("stashdb.org")
+        assert client is None
+
+    @pytest.mark.asyncio
+    async def test_get_client_caches_clients(self):
+        mgr = self._make_manager()
+
+        mock_stash = AsyncMock()
+        mock_stash.get_stashbox_connections.return_value = [
+            {"endpoint": "https://stashdb.org/graphql", "api_key": "key1", "name": "StashDB"},
+        ]
+
+        with patch("stash_client_unified.StashClientUnified", return_value=mock_stash):
+            await mgr.load()
+
+        client1 = mgr.get_client("stashdb.org")
+        client2 = mgr.get_client("stashdb.org")
+        assert client1 is client2
+
+    @pytest.mark.asyncio
+    async def test_refresh_clears_cache(self):
+        mgr = self._make_manager()
+
+        mock_stash = AsyncMock()
+        mock_stash.get_stashbox_connections.return_value = [
+            {"endpoint": "https://stashdb.org/graphql", "api_key": "key1", "name": "StashDB"},
+        ]
+
+        with patch("stash_client_unified.StashClientUnified", return_value=mock_stash):
+            await mgr.load()
+            client_before = mgr.get_client("stashdb.org")
+
+            # Refresh with updated config
+            mock_stash.get_stashbox_connections.return_value = [
+                {"endpoint": "https://stashdb.org/graphql", "api_key": "key2", "name": "StashDB"},
+            ]
+            await mgr.refresh()
+            client_after = mgr.get_client("stashdb.org")
+
+        # Client should be a new instance after refresh
+        assert client_before is not client_after
+        assert client_after.headers["ApiKey"] == "key2"
+
+    @pytest.mark.asyncio
+    async def test_get_endpoint_url(self):
+        mgr = self._make_manager()
+
+        mock_stash = AsyncMock()
+        mock_stash.get_stashbox_connections.return_value = [
+            {"endpoint": "https://stashdb.org/graphql", "api_key": "key1", "name": "StashDB"},
+        ]
+
+        with patch("stash_client_unified.StashClientUnified", return_value=mock_stash):
+            await mgr.load()
+
+        assert mgr.get_endpoint_url("stashdb.org") == "https://stashdb.org/graphql"
+        assert mgr.get_endpoint_url("unknown.org") is None
+
+    @pytest.mark.asyncio
+    async def test_get_connections_excludes_api_keys(self):
+        mgr = self._make_manager()
+
+        mock_stash = AsyncMock()
+        mock_stash.get_stashbox_connections.return_value = [
+            {"endpoint": "https://stashdb.org/graphql", "api_key": "secret-key", "name": "StashDB"},
+        ]
+
+        with patch("stash_client_unified.StashClientUnified", return_value=mock_stash):
+            await mgr.load()
+
+        connections = mgr.get_connections()
+        for conn in connections:
+            assert "api_key" not in conn
+
+
+# ==================== Module singleton ====================
+
+
+class TestModuleSingleton:
+    """Tests for the module-level singleton functions."""
+
+    def test_get_connection_manager_raises_before_init(self):
+        import stashbox_connection_manager as mod
+        original = mod._manager
+        mod._manager = None
+        try:
+            with pytest.raises(RuntimeError, match="not initialized"):
+                get_connection_manager()
+        finally:
+            mod._manager = original
+
+    def test_set_connection_manager(self):
+        import stashbox_connection_manager as mod
+        original = mod._manager
+
+        mock_mgr = MagicMock()
+        set_connection_manager(mock_mgr)
+        assert get_connection_manager() is mock_mgr
+
+        mod._manager = original
+
+
+# ==================== Refresh endpoint integration ====================
+
+
+class TestRefreshEndpoint:
+    """Integration tests for the /system/refresh-stashbox-config endpoint."""
+
+    @pytest.fixture
+    def client(self):
+        """Create a test client with mocked connection manager."""
+        import stashbox_connection_manager as mod
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from settings_router import router, init_settings_router
+
+        # Mock the settings and hardware dependencies
+        import settings as settings_mod
+        import hardware
+        from recommendations_db import RecommendationsDB
+        from hardware import HardwareProfile
+        from settings import init_settings
+
+        original_mgr = settings_mod._settings_manager
+        original_hw = hardware._hardware_profile
+        original_conn = mod._manager
+
+        hardware._hardware_profile = HardwareProfile(
+            gpu_available=True, gpu_name="Test GPU", gpu_vram_mb=8192,
+            cpu_cores=8, memory_total_mb=32768, memory_available_mb=16384,
+            storage_free_mb=500000, tier="gpu-high",
+        )
+
+        import tempfile, os
+        with tempfile.TemporaryDirectory() as tmp:
+            db = RecommendationsDB(os.path.join(tmp, "test.db"))
+            init_settings(db, "gpu-high")
+            init_settings_router()
+
+            # Set up a mock connection manager
+            mock_mgr = MagicMock(spec=StashBoxConnectionManager)
+            mock_mgr.refresh = AsyncMock(return_value=2)
+            mock_mgr.get_connections.return_value = [
+                {"endpoint": "https://stashdb.org/graphql", "name": "StashDB", "domain": "stashdb.org"},
+                {"endpoint": "https://fansdb.cc/graphql", "name": "FansDB", "domain": "fansdb.cc"},
+            ]
+            mod._manager = mock_mgr
+
+            app = FastAPI()
+            app.include_router(router)
+            yield TestClient(app)
+
+        settings_mod._settings_manager = original_mgr
+        hardware._hardware_profile = original_hw
+        mod._manager = original_conn
+
+    def test_refresh_returns_count(self, client):
+        resp = client.post("/system/refresh-stashbox-config")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["endpoints_loaded"] == 2
+        assert len(data["connections"]) == 2
+
+    def test_list_connections(self, client):
+        resp = client.get("/system/stashbox-connections")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["connections"]) == 2
+        assert data["connections"][0]["domain"] == "stashdb.org"


### PR DESCRIPTION
## Summary
- Add `StashBoxConnectionManager` that reads stash-box endpoint config from Stash's GraphQL API at startup, replacing hardcoded env vars (`STASHDB_API_KEY`, `FANSDB_API_KEY`, etc.)
- Refactor `stashbox_utils.py` to delegate client creation to the connection manager, enabling auto-discovery of whatever endpoints the user has configured in Stash
- Add `GET /system/stashbox-connections` and `POST /system/refresh-stashbox-config` endpoints for listing and refreshing config without restart

## Test plan
- [x] 18 new tests covering connection manager, singleton lifecycle, and API endpoints
- [x] Full test suite passes (660/660)
- [ ] Manual: verify sidecar logs show discovered endpoints on startup
- [ ] Manual: verify `/system/stashbox-connections` returns configured endpoints
- [ ] Manual: verify face recognition and upstream sync still work with Stash-sourced config

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)