### PR TITLE
chore: set up MkDocs with GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,31 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install mkdocs-material
+        run: pip install mkdocs-material
+
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ api/test_*.py
 .insightface/
 api/.deepface/
 
+# MkDocs build output
+site/
+
 # IDE
 .idea/
 .vscode/

--- a/docs/stash-box-endpoints.md
+++ b/docs/stash-box-endpoints.md
@@ -137,7 +137,7 @@ The ultimate solution is a public cloud service (similar to stash-box) where use
 - Scale with the community (more users = better models)
 - Preserve privacy (only embeddings, never raw images)
 
-See [project-status-and-vision.md](2026-01-26-project-status-and-vision.md#crowd-sourced-face-database-cloud-service) for full details on the cloud service vision.
+<!-- Future: link to cloud service vision doc when published -->
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,13 +16,19 @@ theme:
 
 nav:
   - Home: index.md
-  - Installation: installation.md
+  - Getting Started:
+    - Installation: installation.md
+    - Configuration: configuration.md
+  - User Guide:
+    - Plugin: plugin.md
+    - Settings: settings-system.md
+    - StashBox Endpoints: stash-box-endpoints.md
   - Unraid:
     - Setup: unraid/setup.md
     - GPU Passthrough: unraid/gpu-passthrough.md
-  - Configuration: configuration.md
-  - Plugin: plugin.md
-  - Troubleshooting: troubleshooting.md
+  - Reference:
+    - Architecture: architecture.md
+    - Troubleshooting: troubleshooting.md
 
 markdown_extensions:
   - admonition
@@ -32,6 +38,10 @@ markdown_extensions:
   - pymdownx.tabbed:
       alternate_style: true
   - tables
+
+not_in_nav: |
+  /plans/**
+  /research/**
 
 extra:
   social:


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow that auto-deploys docs to `gh-pages` on push to main (triggers on `docs/**`, `mkdocs.yml`, or workflow changes)
- Expand mkdocs.yml navigation: Getting Started, User Guide, Unraid, and Reference sections
- Add `architecture.md`, `settings-system.md`, and `stash-box-endpoints.md` to nav
- Fix broken link in stash-box-endpoints.md, exclude internal plans/research from nav

## Test plan
- [x] `mkdocs build --strict` passes locally
- [ ] After merge: verify GitHub Pages deploys at `carrotwaxr.github.io/stash-sense`
- [ ] Verify all nav links work on the deployed site

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)