### PR TITLE
refactor: settings page UI/UX pass with human-friendly interval picker

### DIFF
--- a/api/queue_router.py
+++ b/api/queue_router.py
@@ -77,11 +77,16 @@ async def get_job_types():
         types.append({
             "type_id": defn.type_id,
             "display_name": defn.display_name,
+            "description": defn.description,
             "resource": defn.resource.value,
             "default_priority": int(defn.default_priority),
             "supports_incremental": defn.supports_incremental,
             "schedulable": defn.schedulable,
             "default_interval_hours": defn.default_interval_hours,
+            "allowed_intervals": [
+                {"hours": hours, "label": label}
+                for hours, label in defn.allowed_intervals
+            ],
         })
     return {"types": types}
 

--- a/docs/plans/2026-02-19-settings-ui-ux-pass.md
+++ b/docs/plans/2026-02-19-settings-ui-ux-pass.md
@@ -1,0 +1,140 @@
+# Settings Page UI/UX Pass
+
+**Date:** 2026-02-19
+**Ticket:** refactor: settings page UI/UX pass - consistent components, human-friendly intervals
+
+## Problem
+
+The plugin settings page has accumulated visual inconsistencies:
+- Job Schedules uses raw `<input type="number">` with browser-native spinners and inline styles
+- Interval values displayed as raw hours (168 = 1 week) — meaningless at a glance
+- Three different coding patterns across Sidecar Settings, Job Schedules, and Upstream Sync sections
+- Inline styles scattered throughout `stash-sense-settings.js` instead of CSS classes
+- Inconsistent save patterns: auto-save vs explicit Save button
+
+## Design Decisions
+
+- **Server-side interval definitions**: `JobDefinition` gets `allowed_intervals` and `description` fields. The `queue_types` API serializes them to the frontend. Single source of truth.
+- **Tiered interval presets**: Light/Network jobs get frequent options (6h–2w), heavy/slow-changing jobs get infrequent options (1d–1mo).
+- **Native `<select>` for interval picker**: Styled to match dark theme. Accessible, zero JS overhead, options come from server.
+- **Auto-save everywhere**: All settings auto-save with 500ms debounce, except upstream field config (batch checkbox operation keeps explicit Save).
+- **No new component abstractions**: Use existing CSS classes consistently + add a few new ones. No UI library needed.
+- **Defaults unchanged**: 24h for DB update + upstream, 168h for duplicates + fingerprints.
+
+## Server Changes
+
+### job_models.py
+
+Add predefined interval tiers:
+
+```python
+INTERVALS_FREQUENT = [
+    (6, "Every 6 hours"), (12, "Every 12 hours"),
+    (24, "Every day"), (48, "Every 2 days"), (72, "Every 3 days"),
+    (168, "Every week"), (336, "Every 2 weeks"),
+]
+
+INTERVALS_INFREQUENT = [
+    (24, "Every day"), (48, "Every 2 days"), (72, "Every 3 days"),
+    (168, "Every week"), (336, "Every 2 weeks"), (720, "Every month"),
+]
+```
+
+Extend `JobDefinition`:
+- `description: str` — human-readable description of what the job does
+- `allowed_intervals: list[tuple[int, str]]` — valid interval options for this job type
+
+Job descriptions:
+- Database Update: "Checks for updated face recognition data"
+- Upstream Performer Changes: "Detects field changes from stash-box sources"
+- Duplicate Performer Detection: "Finds performers that may be duplicates"
+- Duplicate Scene File Detection: "Finds scenes with identical file fingerprints"
+- Duplicate Scene Detection: "Finds scenes that may be the same content"
+- Fingerprint Generation: "Generates face recognition fingerprints for scenes"
+
+Interval assignments:
+- `INTERVALS_FREQUENT`: Database Update, Upstream Performer Changes
+- `INTERVALS_INFREQUENT`: All three duplicate detectors, Fingerprint Generation
+
+### queue_router.py
+
+Serialize new fields in `queue_types` response:
+```json
+{
+  "type_id": "database_update",
+  "display_name": "Database Update",
+  "description": "Checks for updated face recognition data",
+  "allowed_intervals": [
+    {"hours": 6, "label": "Every 6 hours"},
+    {"hours": 12, "label": "Every 12 hours"},
+    ...
+  ]
+}
+```
+
+## Frontend Changes
+
+### New CSS classes (stash-sense.css)
+
+- `.ss-select` — styled native `<select>` matching dark theme (same border/bg/font as `.ss-number-input input`)
+- `.ss-setting-hint` — 13px secondary-color text (replaces 4+ inline style occurrences)
+- `.ss-setting-row-vertical` — variant of `.ss-setting-row` with `flex-direction: column`
+- `.ss-setting-row-header` — flex row with space-between for compound row headers
+- `.ss-upstream-fields-wrapper` — wrapper for expandable field config area
+- Fix `.ss-number-input` spinner rules: change from `opacity: 1` to `display: none` / `-webkit-appearance: none`
+
+### Schedule row layout
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Database Update                    [toggle]  [Every day ▾] │
+│  Checks for updated face recognition data                   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+- Description is static (what the job does), not echoing the interval
+- `<select>` disabled when toggle is off
+- Auto-saves on toggle or dropdown change via `debouncedSave` pattern
+
+### renderSchedulesCategory() refactor
+
+- Replace all inline `styles: {}` with CSS classes
+- Replace `<input type="number">` with `<select>` populated from `allowed_intervals`
+- Remove per-row Save button, use debounced auto-save
+- Use `.ss-setting-row`, `.ss-setting-info`, `.ss-setting-control` consistently
+
+### renderEndpointFieldConfig() cleanup
+
+- Inline style on row wrapper → `.ss-setting-row .ss-setting-row-vertical`
+- Inline flex header → `.ss-setting-row-header`
+- "Show Fields" button → `.ss-btn .ss-btn-sm`
+- Fields wrapper → `.ss-upstream-fields-wrapper`
+- Loading/help text → `.ss-setting-hint`
+- Keep explicit Save for batch field config (not auto-save)
+- No behavioral changes
+
+### Other inline style cleanup
+
+- Description/help text throughout → `.ss-setting-hint`
+- Remove all remaining `style:` attributes in `stash-sense-settings.js`
+
+## Not in Scope
+
+- StashBox provider cards at top of settings page
+- Operations tab styling
+- API behavior changes beyond serializing new metadata fields
+
+## Testing
+
+- **Unit**: `JobDefinition` serialization includes `description` and `allowed_intervals` in `queue_types` response
+- **Unit**: Schedule update API accepts hour values from predefined lists
+- **Manual**: Visual verification — no inline styles, consistent alignment, dropdown works, auto-save works
+- **Manual**: Responsive layout at 768px breakpoint
+- **Manual**: Toggle disables/enables dropdown
+
+## Key Files
+
+- `api/job_models.py` — `JobDefinition` extensions, interval tier constants
+- `api/queue_router.py` — serialize new fields
+- `plugin/stash-sense-settings.js` — full refactor of schedule + upstream sync rendering
+- `plugin/stash-sense.css` — new classes, spinner fix

--- a/plugin/stash-sense.css
+++ b/plugin/stash-sense.css
@@ -2366,7 +2366,12 @@
 
 .ss-number-input input::-webkit-inner-spin-button,
 .ss-number-input input::-webkit-outer-spin-button {
-  opacity: 1;
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.ss-number-input input[type="number"] {
+  -moz-appearance: textbox;
 }
 
 .ss-number-input input:focus {
@@ -2378,6 +2383,76 @@
   font-size: 11px;
   color: var(--bs-secondary-color, #666);
   white-space: nowrap;
+}
+
+/* Select Dropdown */
+.ss-select {
+  padding: 6px 10px;
+  background: var(--bs-body-bg, #1a1a1a);
+  border: 1px solid var(--bs-border-color, #444);
+  border-radius: 6px;
+  color: var(--bs-body-color, #fff);
+  font-size: 14px;
+  cursor: pointer;
+  min-width: 140px;
+}
+
+.ss-select:focus {
+  outline: none;
+  border-color: var(--bs-primary, #0d6efd);
+}
+
+.ss-select:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Hint Text (reusable muted description) */
+.ss-setting-hint {
+  color: var(--bs-secondary-color, #888);
+  font-size: 13px;
+}
+
+/* Vertical Setting Row (stacks children) */
+.ss-setting-row-vertical {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0;
+  padding: 12px 16px;
+  background: var(--bs-tertiary-bg, #2a2a2a);
+  border-radius: 8px;
+  position: relative;
+}
+
+.ss-setting-row-vertical:first-child {
+  border-radius: 8px 8px 2px 2px;
+}
+
+.ss-setting-row-vertical:last-child {
+  border-radius: 2px 2px 8px 8px;
+}
+
+.ss-setting-row-vertical:only-child {
+  border-radius: 8px;
+}
+
+/* Row Header (flex row with space-between) */
+.ss-setting-row-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+}
+
+/* Upstream Fields Wrapper */
+.ss-upstream-fields-wrapper {
+  width: 100%;
+  margin-top: 12px;
+}
+
+.ss-upstream-fields-wrapper .ss-setting-control {
+  margin-top: 10px;
 }
 
 /* Toggle Switch */


### PR DESCRIPTION
## Summary
- Replace raw `<input type="number">` in Job Schedules with native `<select>` dropdowns populated from server-defined interval presets (e.g. "Every day", "Every week" instead of raw hours)
- Add `description` and `allowed_intervals` to `JobDefinition` with two tiers: frequent (6h–2w) for light/network jobs, infrequent (1d–1mo) for heavy/slow-changing jobs
- Remove all inline styles from `stash-sense-settings.js`, migrate to CSS classes; add `.ss-select`, `.ss-setting-hint`, `.ss-setting-row-vertical`, `.ss-setting-row-header` classes
- Replace per-row Save buttons with auto-save debounce pattern matching sidecar settings UX
- Hide native number input spinners, disable interval dropdown when toggle is off

## Test plan
- [x] All 686 existing tests pass (0 failures)
- [x] New tests: interval tier ordering, JobDefinition field serialization, queue_types API response format
- [ ] Manual: verify settings page renders correctly with select dropdowns
- [ ] Manual: verify auto-save works on toggle/interval change
- [ ] Manual: verify responsive layout at 768px breakpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)