### PR TITLE
feat: upstream change detection for Tags

### DIFF
--- a/api/analyzers/__init__.py
+++ b/api/analyzers/__init__.py
@@ -11,6 +11,7 @@ from .duplicate_performer import DuplicatePerformerAnalyzer
 from .duplicate_scene_files import DuplicateSceneFilesAnalyzer
 from .duplicate_scenes import DuplicateScenesAnalyzer
 from .upstream_performer import UpstreamPerformerAnalyzer
+from .upstream_tag import UpstreamTagAnalyzer
 
 __all__ = [
     "BaseAnalyzer",
@@ -20,4 +21,5 @@ __all__ = [
     "DuplicateSceneFilesAnalyzer",
     "DuplicateScenesAnalyzer",
     "UpstreamPerformerAnalyzer",
+    "UpstreamTagAnalyzer",
 ]

--- a/api/analyzers/upstream_tag.py
+++ b/api/analyzers/upstream_tag.py
@@ -1,0 +1,71 @@
+"""
+Upstream Tag Changes Analyzer
+
+Detects changes in stash-box linked tags by comparing upstream
+data against local Stash data using 3-way diffing with stored snapshots.
+"""
+
+import logging
+from typing import Optional
+
+from .base_upstream import BaseUpstreamAnalyzer
+from stashbox_client import StashBoxClient
+from upstream_field_mapper import (
+    normalize_upstream_tag,
+    diff_tag_fields,
+    DEFAULT_TAG_FIELDS,
+    TAG_FIELD_LABELS,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _build_local_tag_data(tag: dict) -> dict:
+    """Extract comparable field values from a local Stash tag."""
+    return {
+        "name": tag.get("name"),
+        "description": tag.get("description") or "",
+        "aliases": tag.get("aliases") or [],
+    }
+
+
+class UpstreamTagAnalyzer(BaseUpstreamAnalyzer):
+    """
+    Detects upstream changes in stash-box linked tags.
+
+    Compares tag data from configured stash-box endpoints against
+    local Stash data, using stored snapshots for 3-way diffing.
+    """
+
+    type = "upstream_tag_changes"
+
+    @property
+    def entity_type(self) -> str:
+        return "tag"
+
+    async def _get_local_entities(self, endpoint: str) -> list[dict]:
+        return await self.stash.get_tags_for_endpoint(endpoint)
+
+    async def _get_upstream_entity(self, stashbox_client: StashBoxClient, stashbox_id: str) -> Optional[dict]:
+        return await stashbox_client.get_tag(stashbox_id)
+
+    def _build_local_data(self, entity: dict) -> dict:
+        return _build_local_tag_data(entity)
+
+    def _normalize_upstream(self, raw_data: dict) -> dict:
+        return normalize_upstream_tag(raw_data)
+
+    def _get_default_fields(self) -> set[str]:
+        return DEFAULT_TAG_FIELDS
+
+    def _get_field_labels(self) -> dict[str, str]:
+        return TAG_FIELD_LABELS
+
+    def _diff_fields(
+        self,
+        local_data: dict,
+        upstream_data: dict,
+        snapshot: Optional[dict],
+        enabled_fields: set[str],
+    ) -> list[dict]:
+        return diff_tag_fields(local_data, upstream_data, snapshot, enabled_fields)

--- a/api/stashbox_client.py
+++ b/api/stashbox_client.py
@@ -49,6 +49,22 @@ PERFORMER_FIELDS = """
     updated
 """
 
+# Fragment with all tag fields used by get_tag
+TAG_FIELDS = """
+    id
+    name
+    description
+    aliases
+    category {
+        id
+        name
+        group
+    }
+    deleted
+    created
+    updated
+"""
+
 
 class StashBoxClient:
     """
@@ -160,6 +176,27 @@ class StashBoxClient:
         data = await self._execute(query, variables=variables)
         result = data["queryPerformers"]
         return result["performers"], result["count"]
+
+    async def get_tag(self, tag_id: str) -> Optional[dict]:
+        """
+        Get a single tag by ID from the stash-box endpoint.
+
+        Args:
+            tag_id: The stash-box tag UUID
+
+        Returns:
+            Tag dict if found, None otherwise
+        """
+        query = f"""
+        query FindTag($id: ID!) {{
+            findTag(id: $id) {{
+                {TAG_FIELDS}
+            }}
+        }}
+        """
+
+        data = await self._execute(query, variables={"id": tag_id})
+        return data.get("findTag")
 
     async def get_performer(self, performer_id: str) -> Optional[dict]:
         """

--- a/api/tests/test_upstream_tag_analyzer.py
+++ b/api/tests/test_upstream_tag_analyzer.py
@@ -1,0 +1,266 @@
+"""Tests for UpstreamTagAnalyzer."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class TestUpstreamTagAnalyzer:
+    """Tests for the upstream tag changes analyzer."""
+
+    @pytest.fixture
+    def mock_stash(self):
+        stash = MagicMock()
+        stash.get_stashbox_connections = AsyncMock(return_value=[
+            {"endpoint": "https://stashdb.org/graphql", "api_key": "test-key", "name": "stashdb"},
+        ])
+        stash.get_tags_for_endpoint = AsyncMock(return_value=[])
+        return stash
+
+    @pytest.fixture
+    def rec_db(self, tmp_path):
+        from recommendations_db import RecommendationsDB
+        return RecommendationsDB(tmp_path / "test.db")
+
+    def test_analyzer_type(self, mock_stash, rec_db):
+        from analyzers.upstream_tag import UpstreamTagAnalyzer
+        analyzer = UpstreamTagAnalyzer(mock_stash, rec_db)
+        assert analyzer.type == "upstream_tag_changes"
+
+    def test_entity_type(self, mock_stash, rec_db):
+        from analyzers.upstream_tag import UpstreamTagAnalyzer
+        analyzer = UpstreamTagAnalyzer(mock_stash, rec_db)
+        assert analyzer.entity_type == "tag"
+
+    @pytest.mark.asyncio
+    async def test_no_tags_no_recommendations(self, mock_stash, rec_db):
+        from analyzers.upstream_tag import UpstreamTagAnalyzer
+        mock_stash.get_tags_for_endpoint = AsyncMock(return_value=[])
+        analyzer = UpstreamTagAnalyzer(mock_stash, rec_db)
+        with patch("stashbox_client.StashBoxClient") as MockSBC:
+            mock_sbc = MagicMock()
+            MockSBC.return_value = mock_sbc
+            result = await analyzer.run()
+        assert result.recommendations_created == 0
+
+    @pytest.mark.asyncio
+    async def test_creates_recommendation_for_changed_name(self, mock_stash, rec_db):
+        from analyzers.upstream_tag import UpstreamTagAnalyzer
+        mock_stash.get_tags_for_endpoint = AsyncMock(return_value=[
+            {
+                "id": "10", "name": "Blowjob",
+                "description": "Oral sex performed on a male",
+                "aliases": ["BJ"],
+                "stash_ids": [{"endpoint": "https://stashdb.org/graphql", "stash_id": "tag-uuid-1"}],
+            }
+        ])
+        upstream_tag = {
+            "id": "tag-uuid-1", "name": "Blowjob",
+            "description": "Oral sex performed on a penis",
+            "aliases": ["BJ"],
+            "category": {"id": "cat-1", "name": "Action", "group": "ACTION"},
+            "deleted": False,
+            "created": "2024-01-01T00:00:00Z",
+            "updated": "2026-01-15T10:00:00Z",
+        }
+        analyzer = UpstreamTagAnalyzer(mock_stash, rec_db)
+        with patch("stashbox_client.StashBoxClient") as MockSBC:
+            mock_sbc = MagicMock()
+            mock_sbc.get_tag = AsyncMock(return_value=upstream_tag)
+            MockSBC.return_value = mock_sbc
+            result = await analyzer.run()
+        assert result.recommendations_created == 1
+        recs = rec_db.get_recommendations(type="upstream_tag_changes")
+        assert len(recs) == 1
+        assert recs[0].details["tag_id"] == "10"
+        assert recs[0].details["tag_name"] == "Blowjob"
+        assert any(c["field"] == "description" for c in recs[0].details["changes"])
+
+    @pytest.mark.asyncio
+    async def test_creates_recommendation_for_alias_change(self, mock_stash, rec_db):
+        from analyzers.upstream_tag import UpstreamTagAnalyzer
+        mock_stash.get_tags_for_endpoint = AsyncMock(return_value=[
+            {
+                "id": "10", "name": "Blowjob",
+                "description": "Oral sex",
+                "aliases": ["BJ"],
+                "stash_ids": [{"endpoint": "https://stashdb.org/graphql", "stash_id": "tag-uuid-1"}],
+            }
+        ])
+        upstream_tag = {
+            "id": "tag-uuid-1", "name": "Blowjob",
+            "description": "Oral sex",
+            "aliases": ["BJ", "Fellatio"],
+            "category": None, "deleted": False,
+            "created": "2024-01-01T00:00:00Z",
+            "updated": "2026-01-15T10:00:00Z",
+        }
+        analyzer = UpstreamTagAnalyzer(mock_stash, rec_db)
+        with patch("stashbox_client.StashBoxClient") as MockSBC:
+            mock_sbc = MagicMock()
+            mock_sbc.get_tag = AsyncMock(return_value=upstream_tag)
+            MockSBC.return_value = mock_sbc
+            result = await analyzer.run()
+        assert result.recommendations_created == 1
+        recs = rec_db.get_recommendations(type="upstream_tag_changes")
+        changes = recs[0].details["changes"]
+        assert any(c["field"] == "aliases" for c in changes)
+
+    @pytest.mark.asyncio
+    async def test_no_recommendation_when_in_sync(self, mock_stash, rec_db):
+        from analyzers.upstream_tag import UpstreamTagAnalyzer
+        mock_stash.get_tags_for_endpoint = AsyncMock(return_value=[
+            {
+                "id": "10", "name": "Blowjob",
+                "description": "Oral sex",
+                "aliases": ["BJ"],
+                "stash_ids": [{"endpoint": "https://stashdb.org/graphql", "stash_id": "tag-uuid-1"}],
+            }
+        ])
+        upstream_tag = {
+            "id": "tag-uuid-1", "name": "Blowjob",
+            "description": "Oral sex",
+            "aliases": ["BJ"],
+            "category": None, "deleted": False,
+            "created": "2024-01-01T00:00:00Z",
+            "updated": "2026-01-15T10:00:00Z",
+        }
+        analyzer = UpstreamTagAnalyzer(mock_stash, rec_db)
+        with patch("stashbox_client.StashBoxClient") as MockSBC:
+            mock_sbc = MagicMock()
+            mock_sbc.get_tag = AsyncMock(return_value=upstream_tag)
+            MockSBC.return_value = mock_sbc
+            result = await analyzer.run()
+        assert result.recommendations_created == 0
+
+    @pytest.mark.asyncio
+    async def test_updates_existing_pending_recommendation(self, mock_stash, rec_db):
+        from analyzers.upstream_tag import UpstreamTagAnalyzer
+        rec_db.create_recommendation(
+            type="upstream_tag_changes", target_type="tag",
+            target_id="10", details={"changes": [{"field": "description", "upstream_value": "Old desc"}]},
+            confidence=1.0,
+        )
+        mock_stash.get_tags_for_endpoint = AsyncMock(return_value=[
+            {
+                "id": "10", "name": "Blowjob",
+                "description": "Local desc",
+                "aliases": [],
+                "stash_ids": [{"endpoint": "https://stashdb.org/graphql", "stash_id": "tag-uuid-1"}],
+            }
+        ])
+        upstream_tag = {
+            "id": "tag-uuid-1", "name": "Blowjob",
+            "description": "New upstream desc",
+            "aliases": [],
+            "category": None, "deleted": False,
+            "created": "2024-01-01T00:00:00Z",
+            "updated": "2026-01-16T10:00:00Z",
+        }
+        analyzer = UpstreamTagAnalyzer(mock_stash, rec_db)
+        with patch("stashbox_client.StashBoxClient") as MockSBC:
+            mock_sbc = MagicMock()
+            mock_sbc.get_tag = AsyncMock(return_value=upstream_tag)
+            MockSBC.return_value = mock_sbc
+            result = await analyzer.run()
+        assert result.recommendations_created == 0  # updated, not created
+        recs = rec_db.get_recommendations(type="upstream_tag_changes")
+        assert len(recs) == 1
+        assert any(c["upstream_value"] == "New upstream desc" for c in recs[0].details["changes"])
+
+    @pytest.mark.asyncio
+    async def test_skips_permanently_dismissed(self, mock_stash, rec_db):
+        from analyzers.upstream_tag import UpstreamTagAnalyzer
+        with rec_db._connection() as conn:
+            conn.execute(
+                "INSERT INTO dismissed_targets (type, target_type, target_id, permanent) VALUES (?, ?, ?, ?)",
+                ("upstream_tag_changes", "tag", "10", 1),
+            )
+        mock_stash.get_tags_for_endpoint = AsyncMock(return_value=[
+            {
+                "id": "10", "name": "Blowjob",
+                "description": "Oral sex",
+                "aliases": [],
+                "stash_ids": [{"endpoint": "https://stashdb.org/graphql", "stash_id": "tag-uuid-1"}],
+            }
+        ])
+        upstream_tag = {
+            "id": "tag-uuid-1", "name": "Different Name",
+            "description": "Different desc",
+            "aliases": ["new alias"],
+            "category": None, "deleted": False,
+            "created": "2024-01-01T00:00:00Z",
+            "updated": "2026-01-15T10:00:00Z",
+        }
+        analyzer = UpstreamTagAnalyzer(mock_stash, rec_db)
+        with patch("stashbox_client.StashBoxClient") as MockSBC:
+            mock_sbc = MagicMock()
+            mock_sbc.get_tag = AsyncMock(return_value=upstream_tag)
+            MockSBC.return_value = mock_sbc
+            result = await analyzer.run()
+        assert result.recommendations_created == 0
+
+    @pytest.mark.asyncio
+    async def test_skips_deleted_upstream_tags(self, mock_stash, rec_db):
+        from analyzers.upstream_tag import UpstreamTagAnalyzer
+        mock_stash.get_tags_for_endpoint = AsyncMock(return_value=[
+            {
+                "id": "10", "name": "Blowjob",
+                "description": "Oral sex",
+                "aliases": [],
+                "stash_ids": [{"endpoint": "https://stashdb.org/graphql", "stash_id": "tag-uuid-1"}],
+            }
+        ])
+        upstream_tag = {
+            "id": "tag-uuid-1", "name": "Blowjob",
+            "description": "Oral sex",
+            "aliases": [],
+            "category": None, "deleted": True,
+            "created": "2024-01-01T00:00:00Z",
+            "updated": "2026-01-15T10:00:00Z",
+        }
+        analyzer = UpstreamTagAnalyzer(mock_stash, rec_db)
+        with patch("stashbox_client.StashBoxClient") as MockSBC:
+            mock_sbc = MagicMock()
+            mock_sbc.get_tag = AsyncMock(return_value=upstream_tag)
+            MockSBC.return_value = mock_sbc
+            result = await analyzer.run()
+        assert result.recommendations_created == 0
+
+    @pytest.mark.asyncio
+    async def test_3way_diff_skips_user_intentional_override(self, mock_stash, rec_db):
+        """If upstream == snapshot but local differs, user overrode intentionally."""
+        from analyzers.upstream_tag import UpstreamTagAnalyzer
+
+        # Pre-seed a snapshot
+        rec_db.upsert_upstream_snapshot(
+            entity_type="tag",
+            local_entity_id="10",
+            endpoint="https://stashdb.org/graphql",
+            stash_box_id="tag-uuid-1",
+            upstream_data={"name": "Blowjob", "description": "Upstream desc", "aliases": []},
+            upstream_updated_at="2026-01-14T10:00:00Z",
+        )
+
+        mock_stash.get_tags_for_endpoint = AsyncMock(return_value=[
+            {
+                "id": "10", "name": "Blowjob",
+                "description": "My custom description",  # User changed locally
+                "aliases": [],
+                "stash_ids": [{"endpoint": "https://stashdb.org/graphql", "stash_id": "tag-uuid-1"}],
+            }
+        ])
+        upstream_tag = {
+            "id": "tag-uuid-1", "name": "Blowjob",
+            "description": "Upstream desc",  # Same as snapshot — no upstream change
+            "aliases": [],
+            "category": None, "deleted": False,
+            "created": "2024-01-01T00:00:00Z",
+            "updated": "2026-01-15T10:00:00Z",
+        }
+        analyzer = UpstreamTagAnalyzer(mock_stash, rec_db)
+        with patch("stashbox_client.StashBoxClient") as MockSBC:
+            mock_sbc = MagicMock()
+            mock_sbc.get_tag = AsyncMock(return_value=upstream_tag)
+            MockSBC.return_value = mock_sbc
+            result = await analyzer.run()
+        assert result.recommendations_created == 0

--- a/api/tests/test_upstream_tag_field_mapper.py
+++ b/api/tests/test_upstream_tag_field_mapper.py
@@ -1,0 +1,175 @@
+"""Tests for tag field mapping and 3-way diff engine."""
+
+from upstream_field_mapper import (
+    DEFAULT_TAG_FIELDS,
+    TAG_FIELD_MERGE_TYPES,
+    TAG_FIELD_LABELS,
+    ENTITY_FIELD_CONFIGS,
+    normalize_upstream_tag,
+    diff_tag_fields,
+)
+
+
+class TestTagFieldConfig:
+    def test_tag_registered_in_entity_configs(self):
+        assert "tag" in ENTITY_FIELD_CONFIGS
+        config = ENTITY_FIELD_CONFIGS["tag"]
+        assert config["default_fields"] == DEFAULT_TAG_FIELDS
+        assert config["labels"] == TAG_FIELD_LABELS
+        assert config["merge_types"] == TAG_FIELD_MERGE_TYPES
+
+    def test_default_tag_fields(self):
+        assert DEFAULT_TAG_FIELDS == {"name", "description", "aliases"}
+
+    def test_all_default_fields_have_merge_types(self):
+        for field_name in DEFAULT_TAG_FIELDS:
+            assert field_name in TAG_FIELD_MERGE_TYPES, (
+                f"Field '{field_name}' missing from TAG_FIELD_MERGE_TYPES"
+            )
+
+    def test_all_default_fields_have_labels(self):
+        for field_name in DEFAULT_TAG_FIELDS:
+            assert field_name in TAG_FIELD_LABELS, (
+                f"Field '{field_name}' missing from TAG_FIELD_LABELS"
+            )
+
+    def test_merge_types_correct(self):
+        assert TAG_FIELD_MERGE_TYPES["name"] == "name"
+        assert TAG_FIELD_MERGE_TYPES["description"] == "text"
+        assert TAG_FIELD_MERGE_TYPES["aliases"] == "alias_list"
+
+
+class TestNormalizeUpstreamTag:
+    def test_maps_basic_fields(self):
+        upstream = {
+            "name": "Blowjob",
+            "description": "Oral sex performed on a male",
+        }
+        result = normalize_upstream_tag(upstream)
+        assert result["name"] == "Blowjob"
+        assert result["description"] == "Oral sex performed on a male"
+
+    def test_normalizes_aliases_from_list(self):
+        upstream = {"aliases": ["BJ", "Fellatio"]}
+        result = normalize_upstream_tag(upstream)
+        assert result["aliases"] == ["BJ", "Fellatio"]
+
+    def test_normalizes_none_aliases_to_empty_list(self):
+        upstream = {"aliases": None}
+        result = normalize_upstream_tag(upstream)
+        assert result["aliases"] == []
+
+    def test_omits_category(self):
+        """Category is StashBox-only and should not be included in normalized output."""
+        upstream = {
+            "name": "Blowjob",
+            "description": "Desc",
+            "aliases": [],
+            "category": {"id": "cat-1", "name": "Action", "group": "ACTION"},
+        }
+        result = normalize_upstream_tag(upstream)
+        assert "category" not in result
+
+    def test_handles_missing_fields(self):
+        upstream = {}
+        result = normalize_upstream_tag(upstream)
+        assert result == {}
+
+    def test_handles_none_description(self):
+        upstream = {"name": "Tag", "description": None}
+        result = normalize_upstream_tag(upstream)
+        assert result["description"] is None
+
+
+class TestDiffTagFields:
+    def test_detects_description_change(self):
+        local = {"name": "Blowjob", "description": "Old desc", "aliases": []}
+        upstream = {"name": "Blowjob", "description": "New desc", "aliases": []}
+        snapshot = {"name": "Blowjob", "description": "Old desc", "aliases": []}
+        enabled = {"name", "description", "aliases"}
+
+        changes = diff_tag_fields(local, upstream, snapshot, enabled)
+        assert len(changes) == 1
+        assert changes[0]["field"] == "description"
+        assert changes[0]["local_value"] == "Old desc"
+        assert changes[0]["upstream_value"] == "New desc"
+        assert changes[0]["merge_type"] == "text"
+
+    def test_detects_name_change(self):
+        local = {"name": "BJ", "description": "", "aliases": []}
+        upstream = {"name": "Blowjob", "description": "", "aliases": []}
+        snapshot = {"name": "BJ", "description": "", "aliases": []}
+        enabled = {"name", "description", "aliases"}
+
+        changes = diff_tag_fields(local, upstream, snapshot, enabled)
+        assert len(changes) == 1
+        assert changes[0]["field"] == "name"
+        assert changes[0]["merge_type"] == "name"
+
+    def test_detects_alias_addition(self):
+        local = {"name": "Blowjob", "description": "", "aliases": ["BJ"]}
+        upstream = {"name": "Blowjob", "description": "", "aliases": ["BJ", "Fellatio"]}
+        snapshot = {"name": "Blowjob", "description": "", "aliases": ["BJ"]}
+        enabled = {"name", "description", "aliases"}
+
+        changes = diff_tag_fields(local, upstream, snapshot, enabled)
+        assert len(changes) == 1
+        assert changes[0]["field"] == "aliases"
+        assert changes[0]["merge_type"] == "alias_list"
+
+    def test_alias_diff_is_case_insensitive(self):
+        local = {"aliases": ["BJ", "Fellatio"]}
+        upstream = {"aliases": ["bj", "fellatio"]}
+        snapshot = {"aliases": ["bj", "fellatio"]}
+        enabled = {"aliases"}
+
+        changes = diff_tag_fields(local, upstream, snapshot, enabled)
+        assert len(changes) == 0
+
+    def test_skips_unchanged_upstream_with_snapshot(self):
+        """If upstream == snapshot, user intentionally set local differently."""
+        local = {"name": "My Custom Name", "description": "", "aliases": []}
+        upstream = {"name": "Blowjob", "description": "", "aliases": []}
+        snapshot = {"name": "Blowjob", "description": "", "aliases": []}
+        enabled = {"name", "description", "aliases"}
+
+        changes = diff_tag_fields(local, upstream, snapshot, enabled)
+        assert len(changes) == 0
+
+    def test_first_run_no_snapshot_flags_all_differences(self):
+        local = {"name": "BJ", "description": "Short", "aliases": []}
+        upstream = {"name": "Blowjob", "description": "Long desc", "aliases": ["BJ"]}
+        enabled = {"name", "description", "aliases"}
+
+        changes = diff_tag_fields(local, upstream, None, enabled)
+        assert len(changes) == 3
+        field_names = {c["field"] for c in changes}
+        assert field_names == {"name", "description", "aliases"}
+
+    def test_respects_enabled_fields_filter(self):
+        local = {"name": "BJ", "description": "Short", "aliases": []}
+        upstream = {"name": "Blowjob", "description": "Long desc", "aliases": ["BJ"]}
+        snapshot = {"name": "Old", "description": "Old", "aliases": []}
+        enabled = {"description"}  # only monitoring description
+
+        changes = diff_tag_fields(local, upstream, snapshot, enabled)
+        assert len(changes) == 1
+        assert changes[0]["field"] == "description"
+
+    def test_no_changes_when_all_in_sync(self):
+        local = {"name": "Blowjob", "description": "Desc", "aliases": ["BJ"]}
+        upstream = {"name": "Blowjob", "description": "Desc", "aliases": ["BJ"]}
+        snapshot = {"name": "Blowjob", "description": "Desc", "aliases": ["BJ"]}
+        enabled = {"name", "description", "aliases"}
+
+        changes = diff_tag_fields(local, upstream, snapshot, enabled)
+        assert len(changes) == 0
+
+    def test_empty_values_treated_as_equal(self):
+        """None, empty string, and empty list should all be treated as equal."""
+        local = {"description": None, "aliases": []}
+        upstream = {"description": "", "aliases": []}
+        enabled = {"description", "aliases"}
+
+        changes = diff_tag_fields(local, upstream, None, enabled)
+        assert len(changes) == 0

--- a/api/upstream_field_mapper.py
+++ b/api/upstream_field_mapper.py
@@ -137,6 +137,72 @@ def register_entity_fields(entity_type: str, config: dict):
     ENTITY_FIELD_CONFIGS[entity_type] = config
 
 
+# ==================== Tag Field Config ====================
+
+DEFAULT_TAG_FIELDS: set[str] = {
+    "name",
+    "description",
+    "aliases",
+}
+
+TAG_FIELD_MERGE_TYPES: dict[str, str] = {
+    "name": "name",
+    "description": "text",
+    "aliases": "alias_list",
+}
+
+TAG_FIELD_LABELS: dict[str, str] = {
+    "name": "Name",
+    "description": "Description",
+    "aliases": "Aliases",
+}
+
+# Register tag fields in the entity config registry
+ENTITY_FIELD_CONFIGS["tag"] = {
+    "default_fields": DEFAULT_TAG_FIELDS,
+    "labels": TAG_FIELD_LABELS,
+    "merge_types": TAG_FIELD_MERGE_TYPES,
+}
+
+
+def normalize_upstream_tag(upstream: dict) -> dict:
+    """Convert stash-box tag data to normalized dict using local Stash field names.
+
+    Handles:
+    - Direct field mappings (name, description)
+    - Aliases normalized from None to empty list
+    - Category stored for reference but not diffed
+    """
+    result = {}
+
+    for field_name in ("name", "description"):
+        if field_name in upstream:
+            result[field_name] = upstream[field_name]
+
+    # Aliases: normalize None to empty list
+    if "aliases" in upstream:
+        result["aliases"] = upstream["aliases"] if upstream["aliases"] is not None else []
+
+    return result
+
+
+def diff_tag_fields(
+    local: dict,
+    upstream: dict,
+    snapshot: Optional[dict],
+    enabled_fields: set[str],
+) -> list[dict]:
+    """Convenience wrapper: 3-way diff using tag field config."""
+    return diff_fields(
+        local=local,
+        upstream=upstream,
+        snapshot=snapshot,
+        enabled_fields=enabled_fields,
+        merge_types=TAG_FIELD_MERGE_TYPES,
+        labels=TAG_FIELD_LABELS,
+    )
+
+
 # ==================== Performer-Specific Mapping Constants ====================
 
 # Fields that map directly from upstream to local with the same name

--- a/plugin/stash_sense_backend.py
+++ b/plugin/stash_sense_backend.py
@@ -541,6 +541,18 @@ def handle_recommendations(mode, args, sidecar_url):
             timeout=60,
         )
 
+    elif mode == "rec_update_tag":
+        tag_id = args.get("tag_id")
+        fields = args.get("fields", {})
+        if not tag_id:
+            return {"error": "tag_id required"}
+        return sidecar_post(
+            sidecar_url,
+            "/recommendations/actions/update-tag",
+            {"tag_id": tag_id, "fields": fields},
+            timeout=60,
+        )
+
     elif mode == "rec_dismiss_upstream":
         rec_id = args.get("rec_id")
         if not rec_id:


### PR DESCRIPTION
## Summary
- Adds `UpstreamTagAnalyzer` that detects name, description, and alias changes between local Stash tags and their linked StashBox entries
- Uses the existing 3-way diff engine with snapshot support to respect intentional local overrides
- Full plugin UI for reviewing and applying tag changes from the recommendations dashboard
- 30 new unit and integration tests, all 730 tests pass

## Changes
- **api/stashbox_client.py** — `TAG_FIELDS` fragment + `get_tag()` method
- **api/stash_client_unified.py** — `get_tags_for_endpoint()` + `update_tag()` methods
- **api/upstream_field_mapper.py** — Tag field config, `normalize_upstream_tag()`, `diff_tag_fields()`
- **api/analyzers/upstream_tag.py** — New `UpstreamTagAnalyzer` class
- **api/recommendations_router.py** — Analyzer registration + `/actions/update-tag` endpoint
- **plugin/** — Tag card rendering, detail view, backend proxy route

## Test plan
- [x] 20 unit tests for tag field mapping and 3-way diff
- [x] 10 integration tests for UpstreamTagAnalyzer
- [x] All 730 existing tests pass (0 failures, 1 skipped)

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)