### PR TITLE
Polish dashboard UI with tab persistence and card restyle

### DIFF
--- a/plugin/stash-sense-core.js
+++ b/plugin/stash-sense-core.js
@@ -454,6 +454,23 @@
     return div.innerHTML;
   }
 
+  // ==================== Tab URL State ====================
+
+  function getTabFromUrl() {
+    const params = new URLSearchParams(window.location.search);
+    return params.get('tab') || 'recommendations';
+  }
+
+  function setTabInUrl(tabName) {
+    const url = new URL(window.location.href);
+    if (tabName === 'recommendations') {
+      url.searchParams.delete('tab');
+    } else {
+      url.searchParams.set('tab', tabName);
+    }
+    history.replaceState(null, '', url.toString());
+  }
+
   // ==================== SPA Navigation ====================
 
   const navigationCallbacks = [];
@@ -513,6 +530,8 @@
     getRoute,
     onNavigate,
     initNavigationWatcher,
+    getTabFromUrl,
+    setTabInUrl,
 
     // Utilities
     formatSize,

--- a/plugin/stash-sense-operations.js
+++ b/plugin/stash-sense-operations.js
@@ -415,9 +415,12 @@
     if (document.getElementById('ss-operations')) return;
     if (tabBar.querySelector('[data-tab="operations"]')) return;
 
+    // Check if we should start on this tab
+    const initialTab = SS.getTabFromUrl();
+
     // Create Operations tab button -- insert BEFORE Settings tab
     const operationsTab = SS.createElement('button', {
-      className: 'ss-page-tab',
+      className: `ss-page-tab ${initialTab === 'operations' ? 'active' : ''}`,
       textContent: 'Operations',
       attrs: { 'data-tab': 'operations' },
     });
@@ -429,9 +432,9 @@
       tabBar.appendChild(operationsTab);
     }
 
-    // Create operations panel (hidden by default)
+    // Create operations panel
     const operationsPanel = createOperationsContainer();
-    operationsPanel.style.display = 'none';
+    operationsPanel.style.display = initialTab === 'operations' ? '' : 'none';
     operationsPanel.setAttribute('data-panel', 'operations');
 
     // Insert before settings panel
@@ -442,11 +445,29 @@
       dashboard.appendChild(operationsPanel);
     }
 
+    // If starting on operations tab, hide other panels and lazy load
+    if (initialTab === 'operations') {
+      // Deactivate other tabs
+      tabBar.querySelectorAll('.ss-page-tab').forEach(t => {
+        if (t !== operationsTab) t.classList.remove('active');
+      });
+      // Hide other panels
+      const recPanel = dashboard.querySelector('.ss-page-panel[data-panel="recommendations"]');
+      if (recPanel) recPanel.style.display = 'none';
+      if (settingsPanel) settingsPanel.style.display = 'none';
+      // Load content
+      operationsPanel.dataset.loaded = 'true';
+      renderOperations(operationsPanel);
+    }
+
     // Patch the existing tab click handler to include operations
     tabBar.addEventListener('click', (e) => {
       const btn = e.target.closest('.ss-page-tab');
       if (!btn) return;
       const tabName = btn.dataset.tab;
+
+      // Update URL
+      SS.setTabInUrl(tabName);
 
       // Show/hide operations panel
       operationsPanel.style.display = tabName === 'operations' ? '' : 'none';

--- a/plugin/stash-sense.css
+++ b/plugin/stash-sense.css
@@ -677,13 +677,17 @@
   margin: 0 auto;
 }
 
-/* Dashboard Header */
-.ss-dashboard-header {
-  margin-bottom: 24px;
+/* App Header (above tabs) */
+.ss-app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+  gap: 16px;
 }
 
-.ss-dashboard-header h1 {
-  margin: 0 0 8px 0;
+.ss-app-header-left h1 {
+  margin: 0 0 4px 0;
   font-size: 28px;
   font-weight: 600;
   color: var(--bs-body-color, #fff);
@@ -695,175 +699,202 @@
   font-size: 14px;
 }
 
-/* Stash Status */
-.ss-stash-status {
+/* Status indicator (inline in header) */
+.ss-app-header-right {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 12px 16px;
+  padding: 8px 14px;
   background: var(--bs-tertiary-bg, #2a2a2a);
-  border-radius: 8px;
-  margin-bottom: 24px;
-  font-size: 14px;
+  border-radius: 20px;
+  font-size: 13px;
+  white-space: nowrap;
 }
 
 .ss-status-dot {
-  width: 10px;
-  height: 10px;
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
   background: var(--bs-secondary, #6c757d);
+  flex-shrink: 0;
 }
 
-.ss-stash-status.connected .ss-status-dot {
+.ss-app-header-right.connected .ss-status-dot {
   background: #198754;
 }
 
-.ss-stash-status.disconnected .ss-status-dot {
+.ss-app-header-right.disconnected .ss-status-dot {
   background: #dc3545;
+}
+
+.ss-status-label {
+  color: var(--bs-body-color, #fff);
+  font-weight: 500;
 }
 
 .ss-status-url {
   color: var(--bs-secondary-color, #888);
+  font-size: 12px;
 }
 
 .ss-status-error {
   color: #dc3545;
-  margin-left: auto;
-}
-
-/* Dashboard Summary */
-.ss-dashboard-summary {
-  display: flex;
-  gap: 16px;
-  margin-bottom: 32px;
-}
-
-.ss-summary-card {
-  background: var(--bs-tertiary-bg, #2a2a2a);
-  border-radius: 12px;
-  padding: 24px;
-  flex: 1;
-  text-align: center;
-}
-
-.ss-summary-number {
-  font-size: 48px;
-  font-weight: 700;
-  color: var(--bs-primary, #0d6efd);
-  line-height: 1;
-  margin-bottom: 8px;
-}
-
-.ss-summary-label {
-  color: var(--bs-secondary-color, #888);
-  font-size: 14px;
+  font-size: 12px;
 }
 
 /* Dashboard Sections */
-.ss-dashboard-types,
-.ss-dashboard-actions {
+.ss-dashboard-types {
   margin-bottom: 32px;
 }
 
-.ss-dashboard-types h2,
-.ss-dashboard-actions h2 {
+/* Section Header with inline badge */
+.ss-section-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.ss-section-header h2 {
   font-size: 18px;
   font-weight: 600;
-  margin: 0 0 16px 0;
+  margin: 0;
   color: var(--bs-body-color, #fff);
+}
+
+.ss-count-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  height: 24px;
+  padding: 0 8px;
+  background: var(--bs-primary, #0d6efd);
+  color: #fff;
+  border-radius: 12px;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
 }
 
 /* Type Cards */
 .ss-type-cards {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
-  gap: 16px;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: 12px;
 }
 
 .ss-type-card {
   display: flex;
-  align-items: center;
-  gap: 16px;
+  flex-direction: column;
   background: var(--bs-tertiary-bg, #2a2a2a);
-  border-radius: 12px;
-  padding: 20px;
+  border-radius: 10px;
+  padding: 16px;
   transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
-.ss-type-card:hover {
+.ss-type-card:hover,
+.ss-type-card:focus-within {
   transform: translateY(-2px);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
 }
 
+.ss-type-card-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
 .ss-type-icon {
   flex-shrink: 0;
-  width: 48px;
-  height: 48px;
+  width: 28px;
+  height: 28px;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--bs-body-bg, #1a1a1a);
-  border-radius: 12px;
   color: var(--bs-primary, #0d6efd);
+  margin-top: 1px;
 }
 
-.ss-type-info {
+.ss-type-title-block {
   flex: 1;
   min-width: 0;
 }
 
-.ss-type-info h3 {
-  margin: 0 0 4px 0;
-  font-size: 16px;
+.ss-type-title-block h3 {
+  margin: 0 0 2px 0;
+  font-size: 15px;
   font-weight: 600;
   color: var(--bs-body-color, #fff);
 }
 
-.ss-type-info p {
-  margin: 0 0 8px 0;
-  font-size: 13px;
+.ss-type-title-block p {
+  margin: 0;
+  font-size: 12px;
   color: var(--bs-secondary-color, #888);
+  line-height: 1.4;
+}
+
+/* Card footer: counts + View All */
+.ss-type-card-footer {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding-top: 10px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 .ss-type-counts {
   display: flex;
-  gap: 12px;
-  font-size: 12px;
+  gap: 16px;
+  flex: 1;
 }
 
-.ss-count-pending {
+.ss-count-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1px;
+}
+
+.ss-count-number {
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1.2;
+  font-variant-numeric: tabular-nums;
+}
+
+.ss-count-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  opacity: 0.7;
+}
+
+.ss-count-pending .ss-count-number {
   color: var(--bs-warning, #ffc107);
 }
 
-.ss-count-resolved {
+.ss-count-pending .ss-count-label {
+  color: var(--bs-warning, #ffc107);
+}
+
+.ss-count-resolved .ss-count-number {
   color: #198754;
 }
 
-.ss-count-dismissed {
+.ss-count-resolved .ss-count-label {
+  color: #198754;
+}
+
+.ss-count-dismissed .ss-count-number {
   color: var(--bs-secondary-color, #888);
 }
 
-/* Analysis Buttons */
-.ss-analysis-buttons {
-  display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
-}
-
-.ss-analysis-btn {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.ss-analysis-icon {
-  display: flex;
-  align-items: center;
-}
-
-.ss-analysis-icon svg {
-  width: 18px;
-  height: 18px;
+.ss-count-dismissed .ss-count-label {
+  color: var(--bs-secondary-color, #888);
 }
 
 /* Loading States */
@@ -1355,64 +1386,69 @@
   color: white !important;
 }
 
-/* ==================== Fingerprint Section ==================== */
+/* ==================== Identification Database Section ==================== */
 
-.ss-fingerprint-section {
+.ss-id-database-section {
   background: var(--bs-secondary-bg, #2a2a2a);
-  border-radius: 8px;
+  border-radius: 10px;
   padding: 20px;
   margin-bottom: 24px;
 }
 
-.ss-fingerprint-section h2 {
-  margin: 0 0 8px 0;
-  font-size: 1.2rem;
+.ss-id-database-section h2 {
+  margin: 0 0 6px 0;
+  font-size: 1.1rem;
+  font-weight: 600;
 }
 
-.ss-fingerprint-desc {
+.ss-id-database-desc {
   color: var(--bs-secondary-color, #aaa);
   margin: 0 0 16px 0;
-  font-size: 0.9rem;
+  font-size: 0.85rem;
 }
 
-.ss-fingerprint-stats {
+.ss-id-database-stats {
   display: flex;
-  gap: 24px;
-  margin-bottom: 16px;
+  gap: 12px;
   flex-wrap: wrap;
 }
 
-.ss-fp-stat {
+.ss-db-stat {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 12px 16px;
+  padding: 10px 16px;
   background: var(--bs-tertiary-bg, #333);
-  border-radius: 6px;
+  border-radius: 8px;
   min-width: 80px;
 }
 
-.ss-fp-stat-value {
-  font-size: 1.5rem;
-  font-weight: bold;
+.ss-db-stat-value {
+  font-size: 1.3rem;
+  font-weight: 700;
   color: var(--bs-body-color, #fff);
+  line-height: 1.2;
+  font-variant-numeric: tabular-nums;
 }
 
-.ss-fp-stat-label {
-  font-size: 0.75rem;
+.ss-db-stat-label {
+  font-size: 0.7rem;
   color: var(--bs-secondary-color, #aaa);
   text-transform: uppercase;
+  letter-spacing: 0.3px;
+  margin-top: 2px;
 }
 
-.ss-fp-stat-warning {
-  background: rgba(255, 193, 7, 0.15);
-  border: 1px solid rgba(255, 193, 7, 0.3);
+.ss-db-stat-warning {
+  background: rgba(255, 193, 7, 0.12);
+  border: 1px solid rgba(255, 193, 7, 0.25);
 }
 
-.ss-fp-stat-warning .ss-fp-stat-value {
+.ss-db-stat-warning .ss-db-stat-value {
   color: #ffc107;
 }
 
+/* Legacy fingerprint progress (kept for operations tab) */
 .ss-fingerprint-progress {
   background: var(--bs-tertiary-bg, #333);
   border-radius: 6px;
@@ -1515,6 +1551,7 @@
   color: var(--bs-body-color, #fff);
 }
 
+/* Keep for backward compat but not used on dashboard anymore */
 .ss-fingerprint-actions {
   display: flex;
   gap: 12px;
@@ -1547,13 +1584,18 @@
     gap: 4px;
   }
 
-  .ss-fingerprint-stats {
-    gap: 12px;
+  .ss-id-database-stats {
+    gap: 8px;
   }
 
-  .ss-fp-stat {
+  .ss-db-stat {
     flex: 1;
     min-width: 70px;
+  }
+
+  .ss-app-header {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }
 


### PR DESCRIPTION
## Summary
- Page refresh now stays on the current tab via URL query param
- Header redesigned as "Stash Sense" with inline connection status pill above the tab bar
- Scene Fingerprints section replaced with Identification Database showing performer, face, tattoo, and fingerprint stats
- All action triggers removed from dashboard — it's now purely informational; actions live on the Operations tab
- Recommendation Types renamed to Recommendations with a compact inline pending count badge
- Type cards restyled with smaller inline icons, full-width descriptions, and a footer row with prominent counts and an inline View All button

## Notes
Tab URL state (`?tab=`) is managed in the shared core module so all three tab modules use the same helpers. Accessibility improvements include aria-labels on icon buttons, Escape key on confirm modal, and tabular-nums on numeric displays.