### PR TITLE
fix: register upstream_tag_changes in job registry

### DIFF
--- a/api/job_models.py
+++ b/api/job_models.py
@@ -214,6 +214,18 @@ _register(
 )
 
 _register(
+    "upstream_tag_changes",
+    "Upstream Tag Change Detection",
+    "Detects field changes to tags from stash-box sources",
+    ResourceType.NETWORK,
+    JobPriority.NORMAL,
+    supports_incremental=True,
+    schedulable=True,
+    default_interval_hours=24,
+    allowed_intervals=INTERVALS_FREQUENT,
+)
+
+_register(
     "fingerprint_generation",
     "Fingerprint Generation",
     "Generates face recognition fingerprints for scenes",


### PR DESCRIPTION
## Summary
- Add missing job registry entry for upstream tag change detection so it appears in the Operations tab and Job Schedules settings

## Notes
The analyzer, API endpoint, and plugin UI were all added in #40 but the `_register()` call in `job_models.py` was missed, making the job type invisible in the UI.