### PR TITLE
fix: plugin logging, upstream favorite comparison, tag defaults, and stale recommendations

### DIFF
--- a/api/analyzers/upstream_performer.py
+++ b/api/analyzers/upstream_performer.py
@@ -50,7 +50,6 @@ def _build_local_performer_data(performer: dict) -> dict:
         "career_end_year": career["career_end_year"],
         "urls": performer.get("urls") or [],
         "details": performer.get("details") or "",
-        "favorite": performer.get("favorite", False),
     }
 
 
@@ -63,6 +62,7 @@ class UpstreamPerformerAnalyzer(BaseUpstreamAnalyzer):
     """
 
     type = "upstream_performer_changes"
+    logic_version = 2  # v2: removed favorite field from comparison
 
     @property
     def entity_type(self) -> str:

--- a/api/analyzers/upstream_studio.py
+++ b/api/analyzers/upstream_studio.py
@@ -58,6 +58,7 @@ class UpstreamStudioAnalyzer(BaseUpstreamAnalyzer):
     """
 
     type = "upstream_studio_changes"
+    logic_version = 2  # v2: parent studio uses stashbox ID instead of local numeric ID
 
     @property
     def entity_type(self) -> str:

--- a/api/tests/test_duplicate_scenes_analyzer.py
+++ b/api/tests/test_duplicate_scenes_analyzer.py
@@ -203,10 +203,10 @@ class TestDuplicateCandidatesDB:
             ).fetchone()
             assert row is not None
 
-    def test_schema_version_is_8(self, db):
+    def test_schema_version_is_9(self, db):
         with db._connection() as conn:
             version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
-            assert version == 8
+            assert version == 9
 
     def test_insert_candidate(self, db):
         """Insert a candidate pair."""

--- a/api/tests/test_upstream_field_mapper.py
+++ b/api/tests/test_upstream_field_mapper.py
@@ -69,10 +69,11 @@ class TestNormalizeUpstreamPerformer:
             "https://instagram.com/jane",
         ]
 
-    def test_maps_is_favorite_to_favorite(self):
+    def test_ignores_is_favorite(self):
+        """favorite is local-only metadata, not synced from upstream."""
         upstream = {"is_favorite": True}
         result = normalize_upstream_performer(upstream)
-        assert result["favorite"] is True
+        assert "favorite" not in result
         assert "is_favorite" not in result
 
     def test_handles_none_values(self):

--- a/api/upstream_field_mapper.py
+++ b/api/upstream_field_mapper.py
@@ -36,7 +36,6 @@ DEFAULT_PERFORMER_FIELDS: set[str] = {
     "career_end_year",
     "urls",
     "details",
-    "favorite",
 }
 
 # Merge type for each field, controls how diffs and merges are handled
@@ -63,7 +62,6 @@ FIELD_MERGE_TYPES: dict[str, str] = {
     "career_end_year": "simple",
     "urls": "alias_list",
     "details": "text",
-    "favorite": "simple",
 }
 
 # Human-readable labels for each field
@@ -90,7 +88,6 @@ FIELD_LABELS: dict[str, str] = {
     "career_end_year": "Career End Year",
     "urls": "URLs",
     "details": "Details",
-    "favorite": "Favorite",
 }
 
 # ==================== Entity Field Config Registry ====================
@@ -316,7 +313,6 @@ _DIRECT_FIELDS = [
 # Fields that have different names upstream vs local: upstream_name -> local_name
 _RENAMED_FIELDS = {
     "birth_date": "birthdate",
-    "is_favorite": "favorite",
 }
 
 

--- a/plugin/stash-sense-recommendations.js
+++ b/plugin/stash-sense-recommendations.js
@@ -2927,9 +2927,13 @@
           chip.className = 'ss-scene-tag-chip';
           chip.dataset.stashboxId = tag.id;
 
+          // Check if tag already exists locally (created earlier in this session)
+          const cacheKey = `${endpoint}|${tag.id}`;
+          const cachedId = entityCache.get(cacheKey);
+
           const cb = document.createElement('input');
           cb.type = 'checkbox';
-          cb.checked = true;
+          cb.checked = !!cachedId;  // Only default-check tags that already exist locally
           cb.className = 'ss-scene-tag-add-cb';
           cb.dataset.stashboxId = tag.id;
           cb.dataset.name = tag.name;
@@ -2939,10 +2943,6 @@
 
           chip.appendChild(cb);
           chip.appendChild(nameSpan);
-
-          // Create button or cached status
-          const cacheKey = `${endpoint}|${tag.id}`;
-          const cachedId = entityCache.get(cacheKey);
           if (cachedId) {
             const note = document.createElement('span');
             note.className = 'ss-scene-entity-created';

--- a/plugin/stash_sense_backend.py
+++ b/plugin/stash_sense_backend.py
@@ -92,9 +92,14 @@ def main():
     print(json.dumps(output))
 
 
+def _log_prefix(level_char):
+    """Build Stash log level prefix."""
+    return (b'\x01' + level_char + b'\x02').decode()
+
+
 def log(message):
-    """Log a message to Stash."""
-    print(json.dumps({"log": f"[Stash Sense] {message}"}), file=sys.stderr)
+    """Log an info message to Stash."""
+    print(_log_prefix(b'i') + f"[Stash Sense] {message}\n", file=sys.stderr, flush=True)
 
 
 def health_check(sidecar_url):


### PR DESCRIPTION
## Summary
- Plugin logs now show as info instead of errors in Stash log viewer
- Upstream sync no longer flags locally-favorited performers as needing updates
- New tags in scene upstream matching default to unchecked (opt-in instead of opt-out)
- Re-running upstream analysis auto-clears stale recommendations when comparison logic has changed

## Notes
Adds a `logic_version` attribute to upstream analyzers. When bumped, the next analysis run clears stale snapshots and watermarks for that entity type, forcing full re-evaluation. This resolves the 992 stale studio recs and 413 stale performer recs currently in production.

DB schema version 8 -> 9 (adds `logic_version` column to `analysis_watermarks`).