### PR TITLE
fix: database info 503 on lazy load and studio parent false positives

### DIFF
--- a/api/analyzers/upstream_studio.py
+++ b/api/analyzers/upstream_studio.py
@@ -24,8 +24,9 @@ def _build_local_studio_data(studio: dict, endpoint: str = "") -> dict:
     """Extract comparable field values from a local Stash studio.
 
     For parent_studio, resolves the parent's stashbox ID for the given endpoint
-    so it can be compared against the upstream stashbox UUID. Falls back to the
-    local numeric ID if the parent isn't linked to this endpoint.
+    so it can be compared against the upstream stashbox UUID. If the parent isn't
+    linked to this endpoint, parent_studio stays None — a numeric local ID can't
+    be meaningfully compared against a stash-box UUID.
     """
     parent = studio.get("parent_studio")
     parent_studio_val = None
@@ -37,9 +38,6 @@ def _build_local_studio_data(studio: dict, endpoint: str = "") -> dict:
             if sid["endpoint"] == endpoint:
                 parent_studio_val = sid["stash_id"]
                 break
-        if parent_studio_val is None:
-            # Parent not linked to this endpoint — use local ID as fallback
-            parent_studio_val = str(parent["id"])
 
     return {
         "name": studio.get("name"),
@@ -58,7 +56,7 @@ class UpstreamStudioAnalyzer(BaseUpstreamAnalyzer):
     """
 
     type = "upstream_studio_changes"
-    logic_version = 2  # v2: parent studio uses stashbox ID instead of local numeric ID
+    logic_version = 3  # v3: drop numeric ID fallback for unlinked parent studios
 
     @property
     def entity_type(self) -> str:

--- a/api/tests/test_upstream_studio_field_mapper.py
+++ b/api/tests/test_upstream_studio_field_mapper.py
@@ -186,8 +186,8 @@ class TestBuildLocalStudioData:
         assert result["parent_studio"] == "parent-uuid-1"
         assert result["_parent_studio_name"] == "Parent Studio"
 
-    def test_falls_back_to_local_id_when_parent_not_linked(self):
-        """If parent has no stash_id for this endpoint, fall back to local ID."""
+    def test_none_when_parent_not_linked_to_endpoint(self):
+        """If parent has no stash_id for this endpoint, parent_studio is None."""
         studio = {
             "name": "Sub Studio",
             "url": None,
@@ -200,10 +200,11 @@ class TestBuildLocalStudioData:
             },
         }
         result = _build_local_studio_data(studio, "https://stashdb.org/graphql")
-        assert result["parent_studio"] == "10"
+        assert result["parent_studio"] is None
+        assert result["_parent_studio_name"] == "Parent Studio"
 
-    def test_parent_with_empty_stash_ids(self):
-        """Parent with no stash_ids falls back to local ID."""
+    def test_none_when_parent_has_empty_stash_ids(self):
+        """Parent with no stash_ids results in None parent_studio."""
         studio = {
             "name": "Sub Studio",
             "url": None,
@@ -214,7 +215,8 @@ class TestBuildLocalStudioData:
             },
         }
         result = _build_local_studio_data(studio, "https://stashdb.org/graphql")
-        assert result["parent_studio"] == "10"
+        assert result["parent_studio"] is None
+        assert result["_parent_studio_name"] == "Parent Studio"
 
     def test_no_parent(self):
         studio = {"name": "Studio", "url": "https://example.com", "parent_studio": None}


### PR DESCRIPTION
## Summary
- Fix database info endpoint returning 503 when face recognition is lazily loaded but not yet initialized — falls back to manifest values
- Fix studio parent_studio comparison producing false positives by dropping numeric ID fallback when parent isn't linked to the stash-box endpoint
- Bump studio analyzer logic_version to 3 to force re-analysis and clear stale recommendations

## Notes
RCA on running container found 14 false-positive parent_studio recommendations where 8 had matching parent names (e.g., "Porn Pros" → "Porn Pros") but unmatchable ID formats (numeric vs UUID). Removed the numeric fallback so unlinked parents resolve to None instead.