### PR TITLE
feat: entity matching & linking for upstream scene sync

### DIFF
--- a/api/stash_client_unified.py
+++ b/api/stash_client_unified.py
@@ -607,6 +607,69 @@ class StashClientUnified:
         data = await self._execute(query)
         return data["allTags"]
 
+    async def search_performers(self, query: str, limit: int = 10) -> list[dict]:
+        """Search performers by name/alias using text search."""
+        gql = """
+        query SearchPerformers($filter: FindFilterType!) {
+          findPerformers(filter: $filter) {
+            performers {
+              id
+              name
+              disambiguation
+              alias_list
+              stash_ids {
+                endpoint
+                stash_id
+              }
+            }
+          }
+        }
+        """
+        variables = {"filter": {"q": query, "per_page": limit}}
+        data = await self._execute(gql, variables)
+        return data["findPerformers"]["performers"]
+
+    async def search_tags(self, query: str, limit: int = 10) -> list[dict]:
+        """Search tags by name using text search."""
+        gql = """
+        query SearchTags($filter: FindFilterType!) {
+          findTags(filter: $filter) {
+            tags {
+              id
+              name
+              aliases
+              stash_ids {
+                endpoint
+                stash_id
+              }
+            }
+          }
+        }
+        """
+        variables = {"filter": {"q": query, "per_page": limit}}
+        data = await self._execute(gql, variables)
+        return data["findTags"]["tags"]
+
+    async def search_studios(self, query: str, limit: int = 10) -> list[dict]:
+        """Search studios by name using text search."""
+        gql = """
+        query SearchStudios($filter: FindFilterType!) {
+          findStudios(filter: $filter) {
+            studios {
+              id
+              name
+              stash_ids {
+                endpoint
+                stash_id
+              }
+            }
+          }
+        }
+        """
+        variables = {"filter": {"q": query, "per_page": limit}}
+        data = await self._execute(gql, variables)
+        return data["findStudios"]["studios"]
+
     async def get_tags_for_endpoint(self, endpoint: str) -> list[dict]:
         """Query local Stash for all tags linked to a specific stash-box endpoint."""
         query = """
@@ -672,6 +735,21 @@ class StashClientUnified:
         return data["tagCreate"]
 
     # ==================== Studios ====================
+
+    async def get_all_studios(self) -> list[dict]:
+        """Fetch all studios."""
+        query = """
+        query AllStudios {
+          findStudios(filter: { per_page: -1 }) {
+            studios {
+              id
+              name
+            }
+          }
+        }
+        """
+        data = await self._execute(query)
+        return data["findStudios"]["studios"]
 
     async def get_studios_for_endpoint(self, endpoint: str) -> list[dict]:
         """Query local Stash for all studios linked to a specific stash-box endpoint."""

--- a/api/tests/test_upstream_scene.py
+++ b/api/tests/test_upstream_scene.py
@@ -274,6 +274,9 @@ class TestUpstreamSceneAnalyzer:
                 ],
             }
         ])
+        stash.get_all_performers = AsyncMock(return_value=[])
+        stash.get_all_tags = AsyncMock(return_value=[])
+        stash.get_all_studios = AsyncMock(return_value=[])
         return stash
 
     @pytest.mark.asyncio
@@ -561,6 +564,9 @@ class TestSceneSyncIntegration:
                 ],
             }
         ])
+        stash.get_all_performers = AsyncMock(return_value=[])
+        stash.get_all_tags = AsyncMock(return_value=[])
+        stash.get_all_studios = AsyncMock(return_value=[])
         return stash
 
     @pytest.mark.asyncio

--- a/plugin/stash-sense-recommendations.js
+++ b/plugin/stash-sense-recommendations.js
@@ -155,6 +155,14 @@
       return apiCall('rec_dismiss_upstream', { rec_id: recId, reason, permanent: !!permanent });
     },
 
+    async searchEntities(entityType, query, endpoint) {
+      return apiCall('rec_search_entities', { entity_type: entityType, query, endpoint });
+    },
+
+    async linkEntity(entityType, entityId, endpoint, stashboxId) {
+      return apiCall('rec_link_entity', { entity_type: entityType, entity_id: entityId, endpoint, stashbox_id: stashboxId });
+    },
+
     async createPerformer(stashboxData, endpoint, stashboxId) {
       return apiCall('rec_create_performer', { stashbox_data: stashboxData, endpoint, stashbox_id: stashboxId });
     },
@@ -1711,7 +1719,7 @@
         <h2 style="margin: 0 0 4px 0;">
           <a href="/performers/${performerId}" target="_blank">${details.performer_name || 'Unknown'}</a>
         </h2>
-        <span class="ss-upstream-endpoint-badge">${details.endpoint_name || 'Upstream'}</span>
+        <a href="${details.endpoint.replace(/\/graphql$/, '')}/performers/${details.stash_box_id}" target="_blank" class="ss-upstream-endpoint-badge">${details.endpoint_name || 'Upstream'}</a>
       </div>
     `;
     headerDiv.appendChild(createInfoIcon(() => showHelpModal('Upstream Performer Changes', HELP_UPSTREAM_DETAIL)));
@@ -2056,7 +2064,7 @@
         <h2 style="margin: 0 0 4px 0;">
           <a href="/tags/${tagId}" target="_blank">${details.tag_name || 'Unknown'}</a>
         </h2>
-        <span class="ss-upstream-endpoint-badge">${details.endpoint_name || 'Upstream'}</span>
+        <a href="${details.endpoint.replace(/\/graphql$/, '')}/tags/${details.stash_box_id}" target="_blank" class="ss-upstream-endpoint-badge">${details.endpoint_name || 'Upstream'}</a>
       </div>
     `;
     wrapper.appendChild(headerDiv);
@@ -2364,7 +2372,7 @@
         <h2 style="margin: 0 0 4px 0;">
           <a href="/studios/${studioId}" target="_blank">${details.studio_name || 'Unknown'}</a>
         </h2>
-        <span class="ss-upstream-endpoint-badge">${details.endpoint_name || 'Upstream'}</span>
+        <a href="${details.endpoint.replace(/\/graphql$/, '')}/studios/${details.stash_box_id}" target="_blank" class="ss-upstream-endpoint-badge">${details.endpoint_name || 'Upstream'}</a>
       </div>
     `;
     wrapper.appendChild(headerDiv);
@@ -2609,7 +2617,7 @@
         <h2 style="margin: 0 0 4px 0;">
           <a href="/scenes/${sceneId}" target="_blank">${escapeHtml(details.scene_name || 'Unknown Scene')}</a>
         </h2>
-        <span class="ss-upstream-endpoint-badge">${escapeHtml(details.endpoint_name || 'Upstream')}</span>
+        <a href="${details.endpoint.replace(/\/graphql$/, '')}/scenes/${details.stash_box_id}" target="_blank" class="ss-upstream-endpoint-badge">${escapeHtml(details.endpoint_name || 'Upstream')}</a>
       </div>
     `;
     wrapper.appendChild(headerDiv);
@@ -2741,16 +2749,34 @@
       studioLabel.appendChild(document.createTextNode('Apply studio change'));
       studioRow.appendChild(studioLabel);
 
-      // Create studio button (shown when studio doesn't exist locally)
+      // Link/Create studio (shown when studio doesn't exist locally)
       if (upstreamStudio) {
         const cacheKey = `${endpoint}|${upstreamStudio.id}`;
         const cachedId = entityCache.get(cacheKey);
-        if (cachedId) {
+
+        if (upstreamStudio.local_match) {
+          entityCache.set(cacheKey, upstreamStudio.local_match.id);
+          const note = document.createElement('span');
+          note.className = 'ss-scene-entity-linked';
+          note.textContent = 'Linked';
+          studioRow.appendChild(note);
+        } else if (cachedId) {
           const note = document.createElement('span');
           note.className = 'ss-scene-entity-created';
           note.textContent = `Created (ID: ${cachedId})`;
           studioRow.appendChild(note);
         } else {
+          const dropdown = createEntitySearchDropdown('studio', endpoint, upstreamStudio.id, (localId, localName) => {
+            entityCache.set(cacheKey, localId);
+            const linked = document.createElement('span');
+            linked.className = 'ss-scene-entity-linked';
+            linked.textContent = `Linked: ${localName}`;
+            dropdown.replaceWith(linked);
+            const btn = studioRow.querySelector('.ss-scene-create-btn');
+            if (btn) btn.remove();
+          });
+          studioRow.appendChild(dropdown);
+
           const createBtn = document.createElement('button');
           createBtn.className = 'ss-btn ss-btn-sm ss-scene-create-btn';
           createBtn.textContent = 'Create Studio';
@@ -2768,6 +2794,8 @@
               entityCache.set(cacheKey, result.studio.id);
               createBtn.textContent = `Created (ID: ${result.studio.id})`;
               createBtn.classList.add('ss-btn-success');
+              const dd = studioRow.querySelector('.ss-entity-search-dropdown');
+              if (dd) dd.remove();
             } catch (e) {
               createBtn.textContent = `Failed: ${e.message}`;
               createBtn.disabled = false;
@@ -2807,7 +2835,6 @@
 
           const cb = document.createElement('input');
           cb.type = 'checkbox';
-          cb.checked = true;
           cb.className = 'ss-scene-perf-add-cb';
           cb.dataset.stashboxId = perf.id;
           cb.dataset.name = perf.name || perf.id;
@@ -2822,15 +2849,39 @@
           row.appendChild(cb);
           row.appendChild(nameSpan);
 
-          // Create button or cached status
           const cacheKey = `${endpoint}|${perf.id}`;
           const cachedId = entityCache.get(cacheKey);
-          if (cachedId) {
+
+          // Auto-match: local entity found by name during analysis
+          if (perf.local_match) {
+            entityCache.set(cacheKey, perf.local_match.id);
+            cb.checked = true;
+            const note = document.createElement('span');
+            note.className = 'ss-scene-entity-linked';
+            note.textContent = 'Linked';
+            row.appendChild(note);
+          } else if (cachedId) {
+            cb.checked = true;
             const note = document.createElement('span');
             note.className = 'ss-scene-entity-created';
             note.textContent = `Created (ID: ${cachedId})`;
             row.appendChild(note);
           } else {
+            cb.checked = false;
+            // Search dropdown for manual linking
+            const dropdown = createEntitySearchDropdown('performer', endpoint, perf.id, (localId, localName) => {
+              entityCache.set(cacheKey, localId);
+              cb.checked = true;
+              // Replace dropdown and create button with linked indicator
+              const linked = document.createElement('span');
+              linked.className = 'ss-scene-entity-linked';
+              linked.textContent = `Linked: ${localName}`;
+              dropdown.replaceWith(linked);
+              const btn = row.querySelector('.ss-scene-create-btn');
+              if (btn) btn.remove();
+            });
+            row.appendChild(dropdown);
+
             const createBtn = document.createElement('button');
             createBtn.className = 'ss-btn ss-btn-sm ss-scene-create-btn';
             createBtn.textContent = 'Create';
@@ -2844,8 +2895,12 @@
                   perf.id
                 );
                 entityCache.set(cacheKey, result.performer.id);
+                cb.checked = true;
                 createBtn.textContent = `Created (ID: ${result.performer.id})`;
                 createBtn.classList.add('ss-btn-success');
+                // Remove the search dropdown
+                const dd = row.querySelector('.ss-entity-search-dropdown');
+                if (dd) dd.remove();
               } catch (e) {
                 createBtn.textContent = `Failed`;
                 createBtn.disabled = false;
@@ -2927,13 +2982,11 @@
           chip.className = 'ss-scene-tag-chip';
           chip.dataset.stashboxId = tag.id;
 
-          // Check if tag already exists locally (created earlier in this session)
           const cacheKey = `${endpoint}|${tag.id}`;
           const cachedId = entityCache.get(cacheKey);
 
           const cb = document.createElement('input');
           cb.type = 'checkbox';
-          cb.checked = !!cachedId;  // Only default-check tags that already exist locally
           cb.className = 'ss-scene-tag-add-cb';
           cb.dataset.stashboxId = tag.id;
           cb.dataset.name = tag.name;
@@ -2943,12 +2996,34 @@
 
           chip.appendChild(cb);
           chip.appendChild(nameSpan);
-          if (cachedId) {
+
+          if (tag.local_match) {
+            entityCache.set(cacheKey, tag.local_match.id);
+            cb.checked = true;
+            const note = document.createElement('span');
+            note.className = 'ss-scene-entity-linked';
+            note.textContent = 'Linked';
+            chip.appendChild(note);
+          } else if (cachedId) {
+            cb.checked = true;
             const note = document.createElement('span');
             note.className = 'ss-scene-entity-created';
             note.textContent = '(created)';
             chip.appendChild(note);
           } else {
+            cb.checked = false;
+            const dropdown = createEntitySearchDropdown('tag', endpoint, tag.id, (localId, localName) => {
+              entityCache.set(cacheKey, localId);
+              cb.checked = true;
+              const linked = document.createElement('span');
+              linked.className = 'ss-scene-entity-linked';
+              linked.textContent = 'Linked';
+              dropdown.replaceWith(linked);
+              const btn = chip.querySelector('.ss-scene-create-btn');
+              if (btn) btn.remove();
+            });
+            chip.appendChild(dropdown);
+
             const createBtn = document.createElement('button');
             createBtn.className = 'ss-btn ss-btn-sm ss-scene-create-btn';
             createBtn.textContent = 'Create';
@@ -2962,8 +3037,11 @@
                   tag.id
                 );
                 entityCache.set(cacheKey, result.tag.id);
+                cb.checked = true;
                 createBtn.textContent = 'Created';
                 createBtn.classList.add('ss-btn-success');
+                const dd = chip.querySelector('.ss-entity-search-dropdown');
+                if (dd) dd.remove();
               } catch (e) {
                 createBtn.textContent = 'Fail';
                 createBtn.disabled = false;
@@ -3156,9 +3234,9 @@
         }
       }
 
-      // Block apply if checked entities haven't been created yet
+      // Block apply if checked entities haven't been linked or created yet
       if (uncreated.length > 0) {
-        errorDiv.innerHTML = `<strong>Please create these entities first:</strong><br>${uncreated.map(e => escapeHtml(e)).join('<br>')}`;
+        errorDiv.innerHTML = `<strong>Please link or create these entities first:</strong><br>${uncreated.map(e => escapeHtml(e)).join('<br>')}`;
         errorDiv.style.display = 'block';
         return;
       }
@@ -3431,6 +3509,105 @@
     } else {
       resultContent.innerHTML = `<span class="ss-upstream-alias-result-count">${checkedAliases.length}</span> items<ul style="margin:0.25rem 0 0 1.25rem;padding:0;list-style:disc;">${checkedAliases.map(a => `<li style="font-size:0.8rem;color:#fff;margin-bottom:2px;">${escapeHtml(a)}</li>`).join('')}</ul>`;
     }
+  }
+
+  /**
+   * Create a search dropdown for linking a local entity to a stash-box ID.
+   * @param {string} entityType - "performer", "tag", or "studio"
+   * @param {string} endpoint - stash-box endpoint URL
+   * @param {string} stashboxId - stash-box entity UUID
+   * @param {function} onMatch - callback(localId, localName) when linked
+   * @returns {HTMLElement} the dropdown container element
+   */
+  function createEntitySearchDropdown(entityType, endpoint, stashboxId, onMatch) {
+    const container = document.createElement('div');
+    container.className = 'ss-entity-search-dropdown';
+
+    const trigger = document.createElement('button');
+    trigger.className = 'ss-btn ss-btn-sm ss-entity-link-btn';
+    trigger.textContent = 'Link';
+    container.appendChild(trigger);
+
+    const panel = document.createElement('div');
+    panel.className = 'ss-entity-search-panel';
+    panel.style.display = 'none';
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'ss-entity-search-input';
+    input.placeholder = `Search ${entityType}s...`;
+    panel.appendChild(input);
+
+    const resultsList = document.createElement('div');
+    resultsList.className = 'ss-entity-search-results';
+    panel.appendChild(resultsList);
+
+    container.appendChild(panel);
+
+    let debounceTimer = null;
+
+    trigger.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const isOpen = panel.style.display !== 'none';
+      panel.style.display = isOpen ? 'none' : '';
+      if (!isOpen) {
+        input.focus();
+      }
+    });
+
+    // Close when clicking outside
+    document.addEventListener('click', (e) => {
+      if (!container.contains(e.target)) {
+        panel.style.display = 'none';
+      }
+    });
+
+    input.addEventListener('input', () => {
+      clearTimeout(debounceTimer);
+      const q = input.value.trim();
+      if (q.length < 2) {
+        resultsList.innerHTML = '';
+        return;
+      }
+      debounceTimer = setTimeout(async () => {
+        resultsList.innerHTML = '<div class="ss-entity-search-loading">Searching...</div>';
+        try {
+          const resp = await RecommendationsAPI.searchEntities(entityType, q, endpoint);
+          const results = resp.results || [];
+          if (results.length === 0) {
+            resultsList.innerHTML = '<div class="ss-entity-search-empty">No results</div>';
+            return;
+          }
+          resultsList.innerHTML = '';
+          results.forEach(r => {
+            const item = document.createElement('div');
+            item.className = 'ss-entity-search-result-item';
+            if (r.linked) item.classList.add('ss-entity-already-linked');
+
+            let label = escapeHtml(r.name);
+            if (r.disambiguation) label += ` <span class="ss-entity-search-disambig">(${escapeHtml(r.disambiguation)})</span>`;
+            if (r.linked) label += ' <span class="ss-entity-search-linked-badge">linked</span>';
+
+            item.innerHTML = label;
+            item.addEventListener('click', async () => {
+              item.textContent = 'Linking...';
+              try {
+                await RecommendationsAPI.linkEntity(entityType, r.id, endpoint, stashboxId);
+                panel.style.display = 'none';
+                onMatch(r.id, r.name);
+              } catch (err) {
+                item.textContent = `Failed: ${err.message}`;
+              }
+            });
+            resultsList.appendChild(item);
+          });
+        } catch (err) {
+          resultsList.innerHTML = `<div class="ss-entity-search-empty">Error: ${escapeHtml(err.message)}</div>`;
+        }
+      }, 300);
+    });
+
+    return container;
   }
 
   function escapeHtml(str) {

--- a/plugin/stash-sense.css
+++ b/plugin/stash-sense.css
@@ -1849,6 +1849,12 @@
   color: white;
   padding: 2px 8px;
   border-radius: 4px;
+  text-decoration: none;
+}
+
+a.ss-upstream-endpoint-badge:hover {
+  opacity: 0.85;
+  color: white;
 }
 
 /* Quick action buttons */
@@ -3162,7 +3168,49 @@
 .ss-scene-entity-item.ss-scene-entity-removed { opacity: 0.6; text-decoration: line-through; }
 .ss-scene-entity-name { font-size: 13px; }
 .ss-scene-entity-created { font-size: 11px; color: #4caf50; }
+.ss-scene-entity-linked { font-size: 11px; color: #2196f3; font-weight: 500; }
 .ss-scene-create-btn { font-size: 11px !important; padding: 2px 8px !important; }
+
+/* Entity search dropdown */
+.ss-entity-search-dropdown { position: relative; display: inline-block; }
+.ss-entity-link-btn { font-size: 11px !important; padding: 2px 8px !important; }
+.ss-entity-search-panel {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 100;
+  background: #2a2a2a;
+  border: 1px solid #444;
+  border-radius: 6px;
+  padding: 6px;
+  min-width: 220px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.4);
+  margin-top: 4px;
+}
+.ss-entity-search-input {
+  width: 100%;
+  padding: 4px 8px;
+  border: 1px solid #555;
+  border-radius: 4px;
+  background: #1a1a1a;
+  color: #eee;
+  font-size: 12px;
+  box-sizing: border-box;
+}
+.ss-entity-search-input:focus { outline: none; border-color: var(--bs-primary, #2563eb); }
+.ss-entity-search-results { max-height: 180px; overflow-y: auto; margin-top: 4px; }
+.ss-entity-search-result-item {
+  padding: 5px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  color: #ddd;
+}
+.ss-entity-search-result-item:hover { background: rgba(255,255,255,0.1); }
+.ss-entity-search-result-item.ss-entity-already-linked { opacity: 0.5; }
+.ss-entity-search-loading, .ss-entity-search-empty { font-size: 11px; color: #888; padding: 6px 8px; }
+.ss-entity-search-disambig { color: #999; font-size: 11px; }
+.ss-entity-search-linked-badge { font-size: 10px; background: #444; color: #aaa; padding: 1px 5px; border-radius: 3px; margin-left: 4px; }
 .ss-scene-tag-list { display: flex; flex-wrap: wrap; gap: 6px; }
 .ss-scene-tag-chip { display: flex; align-items: center; gap: 4px; padding: 3px 8px; border-radius: 4px; background: rgba(255,255,255,0.06); font-size: 12px; }
 .ss-scene-tag-chip.ss-scene-tag-removed { opacity: 0.6; text-decoration: line-through; background: rgba(244,67,54,0.1); }

--- a/plugin/stash_sense_backend.py
+++ b/plugin/stash_sense_backend.py
@@ -582,6 +582,25 @@ def handle_recommendations(mode, args, sidecar_url):
             timeout=30,
         )
 
+    elif mode == "rec_search_entities":
+        return sidecar_post(sidecar_url, "/recommendations/actions/search-entities", {
+            "entity_type": args.get("entity_type", ""),
+            "query": args.get("query", ""),
+            "endpoint": args.get("endpoint", ""),
+        })
+
+    elif mode == "rec_link_entity":
+        entity_type = args.get("entity_type", "")
+        entity_id = args.get("entity_id", "")
+        if not entity_type or not entity_id:
+            return {"error": "entity_type and entity_id required"}
+        return sidecar_post(sidecar_url, "/recommendations/actions/link-entity", {
+            "entity_type": entity_type,
+            "entity_id": entity_id,
+            "endpoint": args.get("endpoint", ""),
+            "stashbox_id": args.get("stashbox_id", ""),
+        })
+
     elif mode == "rec_create_performer":
         return sidecar_post(sidecar_url, "/recommendations/actions/create-performer", {
             "stashbox_data": args.get("stashbox_data", {}),


### PR DESCRIPTION
## Summary
- **Auto-match existing entities**: During upstream scene analysis, performers/tags/studios are matched to local entities by name/alias and pre-linked in the UI instead of requiring "Create"
- **Searchable entity dropdown**: When auto-match fails, users can search and select existing local entities via a dropdown, which adds the stash_id link automatically
- **Clickable endpoint badges**: The endpoint chip in recommendation headers now links directly to the entity's page on the stash-box instance

## Test plan
- [ ] Open a scene upstream recommendation — endpoint badge should be a clickable link to the stash-box scene page
- [ ] Run upstream scene analysis on a scene linked to a non-primary endpoint — entities that exist locally should show as "Linked" with pre-checked checkboxes
- [ ] For unmatched entities, click "Link" — type a name — results appear — select one — entity is linked and cached
- [ ] With linked entities, click "Apply" — should work without needing to create entities first
- [ ] Run `pytest tests/ -v` — all 958 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)