### PR TITLE
fix: pass db_version to SceneFingerprintGenerator in fingerprint job

### DIFF
--- a/api/jobs/fingerprint_job.py
+++ b/api/jobs/fingerprint_job.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from base_job import BaseJob, JobContext
 from fingerprint_generator import SceneFingerprintGenerator
-from recommendations_router import get_rec_db, get_stash_client
+from recommendations_router import get_db_version, get_rec_db, get_stash_client
 
 
 class FingerprintGenerationJob(BaseJob):
@@ -15,9 +15,13 @@ class FingerprintGenerationJob(BaseJob):
         if context.is_stop_requested():
             return None
 
+        db_version = get_db_version()
+        if db_version is None:
+            raise RuntimeError("No face recognition database loaded; cannot generate fingerprints")
+
         stash = get_stash_client()
         db = get_rec_db()
-        generator = SceneFingerprintGenerator(stash_client=stash, rec_db=db)
+        generator = SceneFingerprintGenerator(stash_client=stash, rec_db=db, db_version=db_version)
 
         async for progress in generator.generate_all():
             await context.report_progress(

--- a/api/recommendations_router.py
+++ b/api/recommendations_router.py
@@ -569,6 +569,11 @@ def set_db_version(version: str):
     _current_db_version = version
 
 
+def get_db_version() -> Optional[str]:
+    """Get the current face recognition DB version."""
+    return _current_db_version
+
+
 class FingerprintStatusResponse(BaseModel):
     """Response for fingerprint status endpoint."""
     total_fingerprints: int


### PR DESCRIPTION
## Summary
- Fixed `TypeError: SceneFingerprintGenerator.__init__() missing 1 required positional argument: 'db_version'` crash when running fingerprint generation via the queue
- Added `get_db_version()` getter to `recommendations_router.py` (setter existed but no getter)
- Added early `RuntimeError` guard if no face recognition database is loaded
- Updated tests to verify `db_version` is passed through and added test for the `None` guard

## Test plan
- [x] All 958 tests pass (1 skipped - GPU-dependent)
- [x] New test `test_fails_without_db_version` covers the None guard path
- [x] Existing tests updated to patch and verify `db_version` flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)