### PR TITLE
fix: prevent idle unload of face recognition during active use

### DIFF
--- a/api/resource_manager.py
+++ b/api/resource_manager.py
@@ -126,6 +126,20 @@ class ResourceManager:
             logger.warning(f"Loaded resource group: {name} in {elapsed:.2f}s")
             return group.data
 
+    def touch(self, name: str) -> None:
+        """Update the last access time for a loaded resource group.
+
+        Lightweight call to prevent idle unloading while the resource is
+        in active use. No-op if the group is not currently loaded.
+
+        Args:
+            name: Name of the resource group.
+        """
+        with self._lock:
+            group = self._groups.get(name)
+            if group is not None and group.loaded:
+                group.last_access = time.monotonic()
+
     def is_loaded(self, name: str) -> bool:
         """Check if a resource group is currently loaded.
 


### PR DESCRIPTION
## Summary
- `require_db_available()` only called `require()` when resources were NULL, so `last_access` was never updated during active use
- After 30 minutes the idle checker unloaded face recognition mid-operation (e.g. during fingerprint generation), stalling the job
- Adds `ResourceManager.touch()` to update `last_access` without reloading, called on every identify request when resources are already loaded

## Test plan
- [x] 983 tests pass (3 new tests for `touch()`)
- [x] Verified root cause in production logs: `Unloading idle resource group: face_recognition (idle 1821s)` while fingerprint job was actively processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)