### PR TITLE
docs: fix setup guide accuracy issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,19 +21,7 @@ Stash Sense is a sidecar service and Stash plugin that brings AI-powered analysi
 2. **Docker** installed on your system
 3. **NVIDIA GPU** with 4GB+ VRAM recommended (CPU fallback available)
 
-### 1. Download the database
-
-Download the latest release from [stash-sense-data](https://github.com/carrotwaxr/stash-sense-data/releases/latest) and extract it:
-
-```bash
-mkdir -p stash-sense-data
-cd stash-sense-data
-# Download the latest .zip from the releases page
-unzip stash-sense-data-*.zip
-cd ..
-```
-
-### 2. Start the container
+### 1. Start the container
 
 ```bash
 docker run -d \
@@ -42,20 +30,20 @@ docker run -d \
   -p 6960:5000 \
   -e STASH_URL=http://your-stash-host:9999 \
   -e STASH_API_KEY=your-api-key \
-  -v ./stash-sense-data:/data:ro \
+  -v ./stash-sense-data:/data \
   -v stash-sense-insightface:/root/.insightface \
   carrotwaxr/stash-sense:latest
 ```
 
 > **No NVIDIA GPU?** Remove `--gpus all` — the sidecar auto-detects and falls back to CPU mode.
 
-### 3. Verify it's running
+### 2. Verify it's running
 
 ```bash
 curl http://localhost:6960/health
 ```
 
-### 4. Install the Stash plugin
+### 3. Install the Stash plugin
 
 In Stash, go to **Settings > Plugins > Available Plugins** and add this source:
 
@@ -65,16 +53,21 @@ https://carrotwaxr.github.io/stash-sense/plugin/index.yml
 
 Name it **Stash Sense**, then install the plugin and configure the sidecar URL (`http://your-host:6960`).
 
+### 4. Download database and models
+
+Navigate to `/plugins/stash-sense` in Stash to open the Stash Sense dashboard. From the **Settings** tab:
+
+1. **Database** — Click **Update** to download the face recognition database (~1.5 GB)
+2. **Models** — Click **Download All** to download the required ONNX models (~220 MB)
+
 ## Configuration
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `STASH_URL` | Yes | — | URL to your Stash instance (e.g., `http://stash:9999`) |
 | `STASH_API_KEY` | Yes | — | Stash API key (Settings > Security > API Key) |
-| `DATA_DIR` | No | `/data` | Path to database files inside the container |
-| `LOG_LEVEL` | No | `warning` | Logging verbosity: `debug`, `info`, `warning`, `error` |
 
-Additional performance and recognition settings are configurable via the **Settings** tab in the plugin UI. The sidecar auto-tunes defaults based on your hardware.
+Additional performance and recognition settings are configurable via the **Settings** tab in the plugin UI. The sidecar auto-tunes defaults based on your hardware. Stash-box API keys are auto-discovered from your Stash instance's configured metadata providers (Settings > Metadata Providers).
 
 ## Updating
 
@@ -105,7 +98,7 @@ Full documentation: **[https://carrotwaxr.github.io/stash-sense](https://carrotw
 - [Installation Guide](https://carrotwaxr.github.io/stash-sense/installation/)
 - [Configuration](https://carrotwaxr.github.io/stash-sense/configuration/)
 - [Features](https://carrotwaxr.github.io/stash-sense/features/)
-- [Plugin Setup](https://carrotwaxr.github.io/stash-sense/plugin/)
+- [Plugin Setup](https://carrotwaxr.github.io/stash-sense/plugin)
 - [Database & Updates](https://carrotwaxr.github.io/stash-sense/database/)
 - [Settings](https://carrotwaxr.github.io/stash-sense/settings-system/)
 - [Troubleshooting](https://carrotwaxr.github.io/stash-sense/troubleshooting/)

--- a/docs/database.md
+++ b/docs/database.md
@@ -49,7 +49,7 @@ The data directory contains:
 
 Stash Sense uses two separate databases:
 
-- **`performers.db`** + Voyager indices (read-only) — The distributable face recognition data. Updated via stash-sense-data releases. Contains no user-specific information.
+- **`performers.db`** + Voyager indices — The distributable face recognition data. Updated via stash-sense-data releases either in-app (Settings tab) or manually. Contains no user-specific information.
 - **`stash_sense.db`** (read-write, user-local, schema version 9) — Your recommendation history, dismissed items, analysis watermarks, upstream snapshots, scene fingerprints, operation queue, and settings overrides.
 
 This separation means database updates never touch your personal data, and the distributable database contains nothing specific to your library.

--- a/docs/features.md
+++ b/docs/features.md
@@ -156,13 +156,16 @@ Jobs declare which resource slot they need. The scheduler runs all compatible jo
 
 ## Model Management
 
-On-demand download and lifecycle management for optional ONNX models that are not bundled in the Docker image.
+On-demand download and lifecycle management for ONNX models. Models are **not** bundled in the Docker image — they are downloaded from the plugin's Settings tab on first setup.
 
-**Supported optional models:**
+**Models:**
 
-| Model | Purpose | Size |
-|-------|---------|------|
-| Tattoo detection | Identifies tattoos for performer matching | ~50 MB |
+| Model | Purpose | Size | Required |
+|-------|---------|------|----------|
+| FaceNet512 | Face embedding model | ~90 MB | Yes |
+| ArcFace | Face embedding model | ~130 MB | Yes |
+| Tattoo YOLOv5s | Tattoo detection | ~80 MB | No |
+| Tattoo EfficientNet-B0 | Tattoo classification | ~15 MB | No |
 
 **Validation:** Each model download is verified against a SHA256 checksum before activation. If a model file becomes corrupted (disk error, partial write), the sidecar detects the mismatch and marks the model as `corrupted`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ AI-powered performer identification and library curation for [Stash](https://git
 
 ## Get Started
 
-- [Installation](installation.md) — Docker setup, database download, plugin install
+- [Installation](installation.md) — Docker setup, plugin install, database and model download
 - [Plugin Usage](plugin.md) — identifying performers, understanding results
 - [Features](features.md) — full feature overview
 - [Database & Updates](database.md) — where the data comes from, how to update

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -2,35 +2,24 @@
 
 ## Installation
 
-### 1. Copy plugin files to Stash
+### 1. Add the plugin source
 
-Copy the `plugin/` directory contents to your Stash plugins folder:
+In Stash, go to **Settings > Plugins > Available Plugins** and click **Add Source**:
 
-```
-~/.stash/plugins/stash-sense/
-├── stash-sense.yml
-├── stash-sense.js
-├── stash-sense.css
-└── stash_sense_backend.py
-```
+- **Name**: `Stash Sense`
+- **URL**: `https://carrotwaxr.github.io/stash-sense/plugin/index.yml`
 
-Or if using Docker:
+### 2. Install the plugin
 
-```
-/root/.stash/plugins/stash-sense/
-```
+Find **Stash Sense** in the available plugins list and click **Install**.
 
-### 2. Reload plugins
+### 3. Configure the sidecar URL
 
-In Stash: **Settings → Plugins → Reload Plugins**
+Go to **Settings > Plugins > Stash Sense** and set the **Sidecar URL** to the address of your Stash Sense container (e.g., `http://10.0.0.4:6960`).
 
-### 3. Configure the plugin
+### 4. Open the dashboard
 
-In Stash: **Settings → Plugins → Stash Sense**
-
-| Setting | Value |
-|---------|-------|
-| Sidecar URL | `http://localhost:5000` or your Stash Sense host |
+Navigate to **`/plugins/stash-sense`** in your Stash UI to access the Stash Sense dashboard. This is where you'll find the Settings tab, Recommendations dashboard, and Operation Queue.
 
 ## Usage
 
@@ -81,9 +70,9 @@ If a scene doesn't have sprites:
 
 ### "Failed to connect to Stash Sense"
 
-- Verify sidecar is running: `curl http://localhost:5000/health`
-- Check sidecar URL in plugin settings
-- If using Docker, ensure network connectivity
+- Verify sidecar is running: `curl http://localhost:6960/health`
+- Check sidecar URL in plugin settings matches your container's host and port
+- If using Docker, ensure network connectivity between Stash and the sidecar
 
 ### "No faces detected"
 
@@ -111,7 +100,7 @@ The face matched a StashDB performer who isn't in your Stash library. Options:
 
 ### Recommendations Dashboard
 
-The main dashboard (accessible from the Stash navigation) shows all recommendation types:
+The main dashboard is accessible at **`/plugins/stash-sense`** in your Stash UI. It shows all recommendation types:
 
 - **Upstream Changes** — Performer field updates detected from stash-box endpoints, with a 3-way diff view showing local, upstream, and original values
 - **Duplicates** — Candidate duplicate scenes identified by face fingerprint matching

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -17,22 +17,33 @@ docker logs stash-sense
 
 ### "Database not loaded"
 
-The container started but can't find database files.
+The face recognition database hasn't been downloaded yet. This is normal on first startup.
+
+**Fix:** Navigate to `/plugins/stash-sense` in Stash, go to the **Settings** tab, and click **Update** in the Database section to download the database.
+
+Alternatively, verify the volume mount has database files:
 
 ```bash
-# Check what's in the data volume
 docker exec stash-sense ls -la /data
 ```
 
-Should show:
-```
-face_facenet.voy
-face_arcface.voy
-performers.json
-manifest.json
+Should show `face_facenet.voy`, `face_arcface.voy`, `performers.json`, `manifest.json`. If empty, either download via the Settings UI or check your volume mount path.
+
+### "Load model from /app/models/facenet512.onnx failed: File doesn't exist"
+
+The ONNX face recognition models are not bundled in the Docker image — they need to be downloaded after first startup.
+
+**Fix:** Navigate to `/plugins/stash-sense` in Stash, go to the **Settings** tab, and click **Download All** in the Models section. This downloads FaceNet512 (~90 MB) and ArcFace (~130 MB) to `/data/models/`.
+
+Alternatively, download via the API:
+
+```bash
+curl -X POST http://localhost:6960/models/download-all
 ```
 
-If empty, the volume mount is misconfigured or database wasn't extracted.
+### Health check shows "degraded"
+
+This is expected on first startup before the database and models are downloaded. Once you download both from the Settings tab, the status will change to `"healthy"` after the first identification request.
 
 ### Health check failing
 


### PR DESCRIPTION
## Summary
- Fix `/data` volume mount from `:ro` to read-write (sidecar writes `stash_sense.db` and downloads updates here)
- Restructure installation: database and models are downloaded in-app from Settings tab, not manually before startup
- Add missing ONNX model download step (models not bundled in Docker image)
- Add `/plugins/stash-sense` navigation instructions so users know where to find the dashboard
- Remove incorrect stash-box API key env vars (auto-discovered from Stash's metadata providers, not env vars)
- Remove undocumented `LOG_LEVEL` env var
- Fix health check expected response (`"degraded"` on first start, not `"healthy"`)
- Update plugin setup from outdated manual-copy to source URL method
- Add troubleshooting for "facenet512.onnx not found" error
- Fix broken Plugin Setup link in README

## Test plan
- [x] All doc changes are content-only (no code changes)
- [x] Verified against actual code: `main.py`, `stashbox_connection_manager.py`, `model_manager.py`, `Dockerfile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)