### PR TITLE
fix: plugin UI lifecycle cleanup and history state

### DIFF
--- a/plugin/stash-sense-operations.js
+++ b/plugin/stash-sense-operations.js
@@ -40,6 +40,7 @@
 
   let pollInterval = null;
   let jobTypes = null;
+  let historyExpanded = true;
 
   // ==================== Rendering ====================
 
@@ -314,13 +315,16 @@
       className: 'ss-collapsible-header',
       events: {
         click: () => {
-          list.style.display = list.style.display === 'none' ? '' : 'none';
+          historyExpanded = !historyExpanded;
+          list.style.display = historyExpanded ? '' : 'none';
           toggle.classList.toggle('ss-collapsed');
         },
       },
     });
     toggle.textContent = `History (${jobs.length})`;
-    toggle.classList.add('ss-collapsed');
+    if (!historyExpanded) {
+      toggle.classList.add('ss-collapsed');
+    }
     headerRow.appendChild(toggle);
 
     const clearBtn = SS.createElement('button', {
@@ -349,7 +353,9 @@
     const list = SS.createElement('div', {
       className: 'ss-job-list',
     });
-    list.style.display = 'none';
+    if (!historyExpanded) {
+      list.style.display = 'none';
+    }
     for (const job of jobs.slice(0, 20)) {
       list.appendChild(renderJobCard(job, false));
     }
@@ -487,6 +493,13 @@
 
   // ==================== Initialization ====================
 
+  function cleanup() {
+    stopPolling();
+    const operations = document.getElementById('ss-operations');
+    if (operations) operations.remove();
+    jobTypes = null;
+  }
+
   function init() {
     const tryInject = () => {
       if (SS.getRoute().type === 'plugin') {
@@ -503,6 +516,9 @@
         stopPolling();
       }
     });
+
+    // Clean up when leaving plugin page
+    SS.onLeavePlugin(cleanup);
 
     console.log(`[${SS.PLUGIN_NAME}] Operations module loaded`);
   }

--- a/plugin/stash-sense-recommendations.js
+++ b/plugin/stash-sense-recommendations.js
@@ -3914,6 +3914,7 @@
       // Create floating container as last resort
       console.warn('[Stash Sense] No container found, creating overlay');
       mainContainer = document.createElement('div');
+      mainContainer.className = 'ss-floating-overlay';
       mainContainer.style.cssText = 'position: fixed; top: 60px; left: 0; right: 0; bottom: 0; overflow-y: auto; background: var(--bs-body-bg, #1a1a1a); z-index: 100;';
       document.body.appendChild(mainContainer);
     }
@@ -3943,6 +3944,30 @@
 
   // ==================== Initialization ====================
 
+  function cleanup() {
+    // Remove the main dashboard container
+    const dashboard = document.getElementById('ss-recommendations');
+    if (dashboard) dashboard.remove();
+
+    // Remove floating overlay fallback container (if created as last-resort)
+    document.querySelectorAll('.ss-floating-overlay').forEach(el => el.remove());
+
+    // Remove any modal overlays appended to document.body
+    document.querySelectorAll('.ss-modal-overlay').forEach(el => el.remove());
+
+    // Reset state
+    currentState = {
+      view: 'dashboard',
+      type: null,
+      status: 'pending',
+      page: 0,
+      selectedRec: null,
+      counts: null,
+    };
+
+    entityCache.clear();
+  }
+
   function init() {
     // Try to inject if we're already on the plugin page
     setTimeout(injectPluginPage, 300);
@@ -3953,6 +3978,9 @@
         setTimeout(injectPluginPage, 300);
       }
     });
+
+    // Clean up when leaving plugin page
+    SS.onLeavePlugin(cleanup);
 
     console.log(`[${SS.PLUGIN_NAME}] Recommendations module loaded`);
   }

--- a/plugin/stash-sense-settings.js
+++ b/plugin/stash-sense-settings.js
@@ -1125,6 +1125,25 @@
 
   // ==================== Initialization ====================
 
+  function cleanup() {
+    const settings = document.getElementById('ss-settings');
+    if (settings) settings.remove();
+
+    // Clear pending save timeouts
+    for (const key of Object.keys(saveTimeouts)) {
+      clearTimeout(saveTimeouts[key]);
+    }
+    saveTimeouts = {};
+
+    for (const key of Object.keys(scheduleTimeouts)) {
+      clearTimeout(scheduleTimeouts[key]);
+    }
+    scheduleTimeouts = {};
+
+    settingsData = null;
+    systemInfo = null;
+  }
+
   function init() {
     // Try to inject after recommendations module
     const tryInject = () => {
@@ -1140,6 +1159,9 @@
         setTimeout(injectSettingsTab, 600);
       }
     });
+
+    // Clean up when leaving plugin page
+    SS.onLeavePlugin(cleanup);
 
     console.log(`[${SS.PLUGIN_NAME}] Settings module loaded`);
   }


### PR DESCRIPTION
## Summary
- Add `onLeavePlugin` hook to core module for centralized plugin page teardown
- Each module (recommendations, settings, operations) registers cleanup callbacks to remove DOM, clear timers, and reset state on navigation away
- Fix operations history section: defaults to expanded, preserves collapse state across 3s poll re-renders

Closes #62, closes #63

## Test plan
- [ ] Navigate to Stash Sense plugin page → confirm it renders
- [ ] Navigate away to Scenes → confirm plugin content is fully gone
- [ ] Navigate back to plugin page → confirm it re-injects cleanly
- [ ] Go to Operations tab, expand History, wait 6+ seconds → stays expanded
- [ ] Collapse History, wait 6+ seconds → stays collapsed

🤖 Generated with [Claude Code](https://claude.com/claude-code)