### PR TITLE
fix: studio alias resolution, URL arrays, and performer name conflict auto-merge

### DIFF
--- a/api/analyzers/upstream_scene.py
+++ b/api/analyzers/upstream_scene.py
@@ -75,13 +75,18 @@ class UpstreamSceneAnalyzer(BaseUpstreamAnalyzer):
             if name:
                 self._tag_name_lookup[name] = str(t["id"])
 
-        # Studios: name only
+        # Studios: name + aliases
         self._studio_name_lookup = {}
         all_studios = await self.stash.get_all_studios()
         for s in all_studios:
+            sid = str(s["id"])
             name = (s.get("name") or "").strip().lower()
             if name:
-                self._studio_name_lookup[name] = str(s["id"])
+                self._studio_name_lookup[name] = sid
+            for alias in (s.get("aliases") or []):
+                alias_lower = alias.strip().lower()
+                if alias_lower:
+                    self._studio_name_lookup.setdefault(alias_lower, sid)
 
         logger.info(
             f"Name lookups built: {len(self._performer_name_lookup)} performer names, "

--- a/api/analyzers/upstream_studio.py
+++ b/api/analyzers/upstream_studio.py
@@ -39,9 +39,13 @@ def _build_local_studio_data(studio: dict, endpoint: str = "") -> dict:
                 parent_studio_val = sid["stash_id"]
                 break
 
+    urls = studio.get("urls") or []
+    if isinstance(urls, str):
+        urls = [urls] if urls else []
+
     return {
         "name": studio.get("name"),
-        "url": studio.get("url") or None,
+        "urls": urls,
         "parent_studio": parent_studio_val,
         "_parent_studio_name": parent_studio_name,
     }
@@ -56,7 +60,7 @@ class UpstreamStudioAnalyzer(BaseUpstreamAnalyzer):
     """
 
     type = "upstream_studio_changes"
-    logic_version = 4  # v4: suppress false parent_studio diffs when names match
+    logic_version = 5  # v5: url (singular) → urls (array) field
 
     @property
     def entity_type(self) -> str:

--- a/api/stash_client_unified.py
+++ b/api/stash_client_unified.py
@@ -658,6 +658,7 @@ class StashClientUnified:
             studios {
               id
               name
+              aliases
               stash_ids {
                 endpoint
                 stash_id
@@ -744,6 +745,7 @@ class StashClientUnified:
             studios {
               id
               name
+              aliases
             }
           }
         }
@@ -759,7 +761,7 @@ class StashClientUnified:
             studios {
               id
               name
-              url
+              urls
               parent_studio {
                 id
                 name
@@ -804,6 +806,7 @@ class StashClientUnified:
         self,
         name: str,
         stash_ids: list[dict],
+        urls: list[str] | None = None,
         url: str | None = None,
         parent_id: str | None = None,
     ) -> dict:
@@ -817,7 +820,9 @@ class StashClientUnified:
         }
         """
         input_dict: dict = {"name": name, "stash_ids": stash_ids}
-        if url:
+        if urls:
+            input_dict["urls"] = urls
+        elif url:
             input_dict["url"] = url
         if parent_id:
             input_dict["parent_id"] = parent_id

--- a/api/tests/test_update_performer_action.py
+++ b/api/tests/test_update_performer_action.py
@@ -1,0 +1,112 @@
+"""Tests for performer update actions, including auto-merge on name conflict."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def app():
+    """Create a test app with recommendations router."""
+    from fastapi import FastAPI
+    from recommendations_router import router, init_recommendations
+    import tempfile
+    import os
+
+    app = FastAPI()
+    app.include_router(router)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        init_recommendations(db_path, "http://localhost:9999", "test-key")
+        yield app
+
+
+class TestPerformerNameConflictAutoMerge:
+    """When updating a performer name conflicts with an existing performer,
+    auto-merge the conflicting performer into the one being updated."""
+
+    def test_auto_merges_on_name_conflict(self, app):
+        """Reproduces: Upstream renames 'Miss Kenzie Anne' to 'Kenzie Anne',
+        but a local 'Kenzie Anne' already exists. Should merge the conflicting
+        performer into the one being updated, then retry the name update.
+        """
+        with patch("recommendations_router.get_stash_client") as mock_get_stash:
+            mock_stash = MagicMock()
+
+            # First update_performer call fails with name conflict
+            # Second call (after merge) succeeds
+            call_count = 0
+
+            async def mock_update_performer(performer_id, **fields):
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1 and "name" in fields and fields["name"] == "Kenzie Anne":
+                    raise RuntimeError(
+                        'GraphQL error: [{"message": "Name \\"Kenzie Anne\\" already used by '
+                        'performer \\"Kenzie Anne\\" (add a disambiguation to make it unique)"}]'
+                    )
+                return {"id": performer_id}
+
+            mock_stash.update_performer = AsyncMock(side_effect=mock_update_performer)
+
+            # search_performers finds the conflicting performer
+            mock_stash.search_performers = AsyncMock(return_value=[
+                {
+                    "id": "99",
+                    "name": "Kenzie Anne",
+                    "disambiguation": "",
+                    "alias_list": [],
+                    "stash_ids": [],
+                },
+            ])
+
+            # merge_performers succeeds
+            mock_stash.merge_performers = AsyncMock(return_value={"id": "50", "name": "Miss Kenzie Anne"})
+
+            # get_performer for fetching current data (lazy-fetch)
+            mock_stash.get_performer = AsyncMock(return_value={
+                "id": "50",
+                "name": "Miss Kenzie Anne",
+                "alias_list": [],
+                "stash_ids": [{"endpoint": "https://stashdb.org/graphql", "stash_id": "uuid-123"}],
+            })
+
+            mock_get_stash.return_value = mock_stash
+
+            # Clear entity name cache
+            import recommendations_router
+            recommendations_router._entity_name_cache_loaded.clear()
+            recommendations_router._entity_name_cache.clear()
+
+            client = TestClient(app)
+            resp = client.post("/recommendations/actions/update-performer", json={
+                "performer_id": "50",
+                "fields": {"name": "Kenzie Anne"},
+            })
+
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["success"] is True
+            # Should have merged the conflicting performer
+            assert data.get("auto_merged") is True
+            assert data.get("merged_performer_id") == "99"
+            # Should have called merge_performers
+            mock_stash.merge_performers.assert_called_once_with(["99"], "50")
+
+    def test_no_merge_on_non_name_conflict_error(self, app):
+        """Regular errors should propagate normally, not trigger merge logic."""
+        with patch("recommendations_router.get_stash_client") as mock_get_stash:
+            mock_stash = MagicMock()
+            mock_stash.update_performer = AsyncMock(
+                side_effect=RuntimeError("Some other GraphQL error")
+            )
+            mock_get_stash.return_value = mock_stash
+
+            client = TestClient(app)
+            resp = client.post("/recommendations/actions/update-performer", json={
+                "performer_id": "50",
+                "fields": {"country": "US"},
+            })
+
+            assert resp.status_code == 500

--- a/api/tests/test_update_studio_action.py
+++ b/api/tests/test_update_studio_action.py
@@ -72,3 +72,69 @@ class TestUpdateStudioEndpoint:
                 "endpoint": "https://stashdb.org/graphql",
             })
             assert resp.status_code == 200
+
+
+class TestResolveStashboxStudioToLocal:
+    """Tests for _resolve_stashbox_studio_to_local parent studio resolution."""
+
+    @pytest.fixture
+    def app_and_db(self):
+        from fastapi import FastAPI
+        from recommendations_router import router, init_recommendations
+        import tempfile, os
+        app = FastAPI()
+        app.include_router(router)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            init_recommendations(db_path, "http://localhost:9999", "test-key")
+            yield app
+
+    @pytest.mark.asyncio
+    async def test_finds_studio_by_alias_match(self, app_and_db):
+        """When upstream name matches a local studio alias, link instead of create.
+
+        Reproduces: StashBox parent 'Jacquie et Michel' should match local
+        'Jacquie & Michel TV' which has alias 'Jacquie et Michel'.
+        """
+        from recommendations_router import _resolve_stashbox_studio_to_local
+
+        mock_stash = MagicMock()
+
+        # Step 1: stash_box_id lookup returns no results
+        # Step 2: search_studios returns the local studio that has the alias
+        async def mock_execute(query, variables=None, **kwargs):
+            if "stash_id_endpoint" in str(variables):
+                return {"findStudios": {"studios": []}}
+            raise AssertionError(f"Unexpected _execute call: {query}")
+        mock_stash._execute = AsyncMock(side_effect=mock_execute)
+
+        # search_studios returns a studio whose primary name differs but has matching alias
+        mock_stash.search_studios = AsyncMock(return_value=[
+            {
+                "id": "42",
+                "name": "Jacquie & Michel TV",
+                "aliases": ["Jacquie et Michel"],
+                "stash_ids": [],
+            }
+        ])
+        mock_stash.update_studio = AsyncMock(return_value={"id": "42"})
+
+        # Mock stashbox client to return upstream studio data
+        mock_sbc = MagicMock()
+        mock_sbc.get_studio = AsyncMock(return_value={
+            "name": "Jacquie et Michel",
+            "urls": [{"url": "https://jacquieetmichel.net"}],
+        })
+
+        with patch("stashbox_connection_manager.get_connection_manager") as mock_mgr:
+            mock_mgr.return_value.get_client.return_value = mock_sbc
+
+            result = await _resolve_stashbox_studio_to_local(
+                mock_stash, "parent-stashbox-uuid", "https://stashdb.org/graphql"
+            )
+
+        # Should find and link the existing studio, not try to create
+        assert result == "42"
+        mock_stash.update_studio.assert_called_once()
+        # Should NOT have tried to create a new studio
+        assert not hasattr(mock_stash, 'create_studio') or not mock_stash.create_studio.called

--- a/api/tests/test_upstream_studio_analyzer.py
+++ b/api/tests/test_upstream_studio_analyzer.py
@@ -44,7 +44,7 @@ class TestUpstreamStudioAnalyzer:
     async def test_creates_recommendation_for_changed_name(self, mock_stash, rec_db):
         from analyzers.upstream_studio import UpstreamStudioAnalyzer
         mock_stash.get_studios_for_endpoint = AsyncMock(return_value=[
-            {"id": "10", "name": "Brazzrs", "url": "https://brazzers.com",
+            {"id": "10", "name": "Brazzrs", "urls": ["https://brazzers.com"],
              "parent_studio": None,
              "stash_ids": [{"endpoint": "https://stashdb.org/graphql", "stash_id": "studio-uuid-1"}]}
         ])
@@ -70,7 +70,7 @@ class TestUpstreamStudioAnalyzer:
     async def test_creates_recommendation_for_url_change(self, mock_stash, rec_db):
         from analyzers.upstream_studio import UpstreamStudioAnalyzer
         mock_stash.get_studios_for_endpoint = AsyncMock(return_value=[
-            {"id": "10", "name": "Brazzers", "url": "https://old.com",
+            {"id": "10", "name": "Brazzers", "urls": ["https://old.com"],
              "parent_studio": None,
              "stash_ids": [{"endpoint": "https://stashdb.org/graphql", "stash_id": "studio-uuid-1"}]}
         ])
@@ -87,13 +87,13 @@ class TestUpstreamStudioAnalyzer:
             result = await analyzer.run()
         assert result.recommendations_created == 1
         changes = rec_db.get_recommendations(type="upstream_studio_changes")[0].details["changes"]
-        assert any(c["field"] == "url" for c in changes)
+        assert any(c["field"] == "urls" for c in changes)
 
     @pytest.mark.asyncio
     async def test_creates_recommendation_for_parent_change(self, mock_stash, rec_db):
         from analyzers.upstream_studio import UpstreamStudioAnalyzer
         mock_stash.get_studios_for_endpoint = AsyncMock(return_value=[
-            {"id": "20", "name": "Brazzers Exxtra", "url": None,
+            {"id": "20", "name": "Brazzers Exxtra", "urls": [],
              "parent_studio": None,
              "stash_ids": [{"endpoint": "https://stashdb.org/graphql", "stash_id": "studio-uuid-2"}]}
         ])
@@ -116,7 +116,7 @@ class TestUpstreamStudioAnalyzer:
     async def test_no_recommendation_when_in_sync(self, mock_stash, rec_db):
         from analyzers.upstream_studio import UpstreamStudioAnalyzer
         mock_stash.get_studios_for_endpoint = AsyncMock(return_value=[
-            {"id": "10", "name": "Brazzers", "url": "https://brazzers.com",
+            {"id": "10", "name": "Brazzers", "urls": ["https://brazzers.com"],
              "parent_studio": None,
              "stash_ids": [{"endpoint": "https://stashdb.org/graphql", "stash_id": "studio-uuid-1"}]}
         ])
@@ -142,7 +142,7 @@ class TestUpstreamStudioAnalyzer:
                 ("upstream_studio_changes", "studio", "10", 1),
             )
         mock_stash.get_studios_for_endpoint = AsyncMock(return_value=[
-            {"id": "10", "name": "Brazzers", "url": None, "parent_studio": None,
+            {"id": "10", "name": "Brazzers", "urls": [], "parent_studio": None,
              "stash_ids": [{"endpoint": "https://stashdb.org/graphql", "stash_id": "studio-uuid-1"}]}
         ])
         upstream = {
@@ -162,7 +162,7 @@ class TestUpstreamStudioAnalyzer:
     async def test_skips_deleted_upstream_studios(self, mock_stash, rec_db):
         from analyzers.upstream_studio import UpstreamStudioAnalyzer
         mock_stash.get_studios_for_endpoint = AsyncMock(return_value=[
-            {"id": "10", "name": "Brazzers", "url": None, "parent_studio": None,
+            {"id": "10", "name": "Brazzers", "urls": [], "parent_studio": None,
              "stash_ids": [{"endpoint": "https://stashdb.org/graphql", "stash_id": "studio-uuid-1"}]}
         ])
         upstream = {
@@ -182,7 +182,7 @@ class TestUpstreamStudioAnalyzer:
         """Regression: parent_studio should compare stashbox UUIDs, not local ID vs UUID."""
         from analyzers.upstream_studio import UpstreamStudioAnalyzer
         mock_stash.get_studios_for_endpoint = AsyncMock(return_value=[
-            {"id": "20", "name": "Brazzers Exxtra", "url": None,
+            {"id": "20", "name": "Brazzers Exxtra", "urls": [],
              "parent_studio": {
                  "id": "10", "name": "Brazzers",
                  "stash_ids": [{"endpoint": "https://stashdb.org/graphql", "stash_id": "parent-uuid-1"}],
@@ -208,7 +208,7 @@ class TestUpstreamStudioAnalyzer:
         """Display names should be included in parent_studio change details."""
         from analyzers.upstream_studio import UpstreamStudioAnalyzer
         mock_stash.get_studios_for_endpoint = AsyncMock(return_value=[
-            {"id": "20", "name": "Sub Studio", "url": None,
+            {"id": "20", "name": "Sub Studio", "urls": [],
              "parent_studio": {
                  "id": "10", "name": "Old Parent",
                  "stash_ids": [{"endpoint": "https://stashdb.org/graphql", "stash_id": "old-parent-uuid"}],
@@ -240,11 +240,11 @@ class TestUpstreamStudioAnalyzer:
         rec_db.upsert_upstream_snapshot(
             entity_type="studio", local_entity_id="10",
             endpoint="https://stashdb.org/graphql", stash_box_id="studio-uuid-1",
-            upstream_data={"name": "Brazzers", "url": "https://brazzers.com", "parent_studio": None},
+            upstream_data={"name": "Brazzers", "urls": ["https://brazzers.com"], "parent_studio": None},
             upstream_updated_at="2026-01-14T10:00:00Z",
         )
         mock_stash.get_studios_for_endpoint = AsyncMock(return_value=[
-            {"id": "10", "name": "My Custom Studio Name", "url": "https://brazzers.com",
+            {"id": "10", "name": "My Custom Studio Name", "urls": ["https://brazzers.com"],
              "parent_studio": None,
              "stash_ids": [{"endpoint": "https://stashdb.org/graphql", "stash_id": "studio-uuid-1"}]}
         ])

--- a/api/tests/test_upstream_studio_field_mapper.py
+++ b/api/tests/test_upstream_studio_field_mapper.py
@@ -20,7 +20,7 @@ class TestStudioFieldConfig:
         assert config["merge_types"] == STUDIO_FIELD_MERGE_TYPES
 
     def test_default_studio_fields(self):
-        assert DEFAULT_STUDIO_FIELDS == {"name", "url", "parent_studio"}
+        assert DEFAULT_STUDIO_FIELDS == {"name", "urls", "parent_studio"}
 
     def test_all_default_fields_have_merge_types(self):
         for field_name in DEFAULT_STUDIO_FIELDS:
@@ -32,7 +32,7 @@ class TestStudioFieldConfig:
 
     def test_merge_types_correct(self):
         assert STUDIO_FIELD_MERGE_TYPES["name"] == "name"
-        assert STUDIO_FIELD_MERGE_TYPES["url"] == "simple"
+        assert STUDIO_FIELD_MERGE_TYPES["urls"] == "alias_list"
         assert STUDIO_FIELD_MERGE_TYPES["parent_studio"] == "simple"
 
 
@@ -42,20 +42,42 @@ class TestNormalizeUpstreamStudio:
         result = normalize_upstream_studio(upstream)
         assert result["name"] == "Brazzers"
 
-    def test_extracts_first_url(self):
+    def test_extracts_all_urls(self):
+        """Studios can have multiple URLs, all should be preserved."""
         upstream = {"name": "Brazzers", "urls": [{"url": "https://brazzers.com"}, {"url": "https://brazzers.net"}], "parent": None}
         result = normalize_upstream_studio(upstream)
-        assert result["url"] == "https://brazzers.com"
+        assert result["urls"] == ["https://brazzers.com", "https://brazzers.net"]
 
-    def test_empty_url_list_gives_none(self):
+    def test_single_url(self):
+        upstream = {"name": "Brazzers", "urls": [{"url": "https://brazzers.com"}], "parent": None}
+        result = normalize_upstream_studio(upstream)
+        assert result["urls"] == ["https://brazzers.com"]
+
+    def test_empty_url_list_gives_empty_list(self):
         upstream = {"name": "Brazzers", "urls": [], "parent": None}
         result = normalize_upstream_studio(upstream)
-        assert result["url"] is None
+        assert result["urls"] == []
 
-    def test_none_url_list_gives_none(self):
+    def test_none_url_list_gives_empty_list(self):
         upstream = {"name": "Brazzers", "urls": None, "parent": None}
         result = normalize_upstream_studio(upstream)
-        assert result["url"] is None
+        assert result["urls"] == []
+
+    def test_four_urls_vouyermedia_case(self):
+        """Reproduces: Vouyer Media has 4 URLs on StashDB, all should be preserved."""
+        upstream = {
+            "name": "Vouyer Media",
+            "urls": [
+                {"url": "https://vouyermedia.com/"},
+                {"url": "https://twitter.com/vouyermedia"},
+                {"url": "https://www.instagram.com/vouyermedia/"},
+                {"url": "https://www.imdb.com/company/co0139498/"},
+            ],
+            "parent": None,
+        }
+        result = normalize_upstream_studio(upstream)
+        assert len(result["urls"]) == 4
+        assert result["urls"][0] == "https://vouyermedia.com/"
 
     def test_extracts_parent_id(self):
         upstream = {"name": "Brazzers Exxtra", "urls": [], "parent": {"id": "parent-uuid-1", "name": "Brazzers"}}
@@ -85,65 +107,75 @@ class TestNormalizeUpstreamStudio:
 
 class TestDiffStudioFields:
     def test_detects_name_change(self):
-        local = {"name": "Brazzrs", "url": "https://brazzers.com", "parent_studio": None}
-        upstream = {"name": "Brazzers", "url": "https://brazzers.com", "parent_studio": None}
-        snapshot = {"name": "Brazzrs", "url": "https://brazzers.com", "parent_studio": None}
-        changes = diff_studio_fields(local, upstream, snapshot, {"name", "url", "parent_studio"})
+        local = {"name": "Brazzrs", "urls": ["https://brazzers.com"], "parent_studio": None}
+        upstream = {"name": "Brazzers", "urls": ["https://brazzers.com"], "parent_studio": None}
+        snapshot = {"name": "Brazzrs", "urls": ["https://brazzers.com"], "parent_studio": None}
+        changes = diff_studio_fields(local, upstream, snapshot, {"name", "urls", "parent_studio"})
         assert len(changes) == 1
         assert changes[0]["field"] == "name"
         assert changes[0]["merge_type"] == "name"
 
-    def test_detects_url_change(self):
-        local = {"name": "Brazzers", "url": "https://old.com", "parent_studio": None}
-        upstream = {"name": "Brazzers", "url": "https://brazzers.com", "parent_studio": None}
-        snapshot = {"name": "Brazzers", "url": "https://old.com", "parent_studio": None}
-        changes = diff_studio_fields(local, upstream, snapshot, {"name", "url", "parent_studio"})
+    def test_detects_url_addition(self):
+        """When upstream adds a new URL, it should be detected as a change."""
+        local = {"name": "Brazzers", "urls": ["https://brazzers.com"], "parent_studio": None}
+        upstream = {"name": "Brazzers", "urls": ["https://brazzers.com", "https://brazzers.net"], "parent_studio": None}
+        snapshot = {"name": "Brazzers", "urls": ["https://brazzers.com"], "parent_studio": None}
+        changes = diff_studio_fields(local, upstream, snapshot, {"name", "urls", "parent_studio"})
         assert len(changes) == 1
-        assert changes[0]["field"] == "url"
+        assert changes[0]["field"] == "urls"
+        assert changes[0]["merge_type"] == "alias_list"
+
+    def test_no_diff_when_urls_match_regardless_of_order(self):
+        """URL comparison should be set-based (order doesn't matter)."""
+        local = {"name": "X", "urls": ["https://b.com", "https://a.com"], "parent_studio": None}
+        upstream = {"name": "X", "urls": ["https://a.com", "https://b.com"], "parent_studio": None}
+        snapshot = {"name": "X", "urls": ["https://a.com", "https://b.com"], "parent_studio": None}
+        changes = diff_studio_fields(local, upstream, snapshot, {"urls"})
+        assert len(changes) == 0
 
     def test_detects_parent_change(self):
-        local = {"name": "Sub Studio", "url": None, "parent_studio": None}
-        upstream = {"name": "Sub Studio", "url": None, "parent_studio": "parent-uuid-1"}
-        snapshot = {"name": "Sub Studio", "url": None, "parent_studio": None}
-        changes = diff_studio_fields(local, upstream, snapshot, {"name", "url", "parent_studio"})
+        local = {"name": "Sub Studio", "urls": [], "parent_studio": None}
+        upstream = {"name": "Sub Studio", "urls": [], "parent_studio": "parent-uuid-1"}
+        snapshot = {"name": "Sub Studio", "urls": [], "parent_studio": None}
+        changes = diff_studio_fields(local, upstream, snapshot, {"name", "urls", "parent_studio"})
         assert len(changes) == 1
         assert changes[0]["field"] == "parent_studio"
 
     def test_no_changes_when_in_sync(self):
-        data = {"name": "Brazzers", "url": "https://brazzers.com", "parent_studio": None}
-        changes = diff_studio_fields(data, data, data, {"name", "url", "parent_studio"})
+        data = {"name": "Brazzers", "urls": ["https://brazzers.com"], "parent_studio": None}
+        changes = diff_studio_fields(data, data, data, {"name", "urls", "parent_studio"})
         assert len(changes) == 0
 
     def test_skips_unchanged_upstream_with_snapshot(self):
-        local = {"name": "My Custom Name", "url": None, "parent_studio": None}
-        upstream = {"name": "Brazzers", "url": None, "parent_studio": None}
-        snapshot = {"name": "Brazzers", "url": None, "parent_studio": None}
-        changes = diff_studio_fields(local, upstream, snapshot, {"name", "url", "parent_studio"})
+        local = {"name": "My Custom Name", "urls": [], "parent_studio": None}
+        upstream = {"name": "Brazzers", "urls": [], "parent_studio": None}
+        snapshot = {"name": "Brazzers", "urls": [], "parent_studio": None}
+        changes = diff_studio_fields(local, upstream, snapshot, {"name", "urls", "parent_studio"})
         assert len(changes) == 0
 
     def test_first_run_no_snapshot_flags_all_differences(self):
-        local = {"name": "Brazzrs", "url": None, "parent_studio": None}
-        upstream = {"name": "Brazzers", "url": "https://brazzers.com", "parent_studio": "parent-uuid"}
-        changes = diff_studio_fields(local, upstream, None, {"name", "url", "parent_studio"})
+        local = {"name": "Brazzrs", "urls": [], "parent_studio": None}
+        upstream = {"name": "Brazzers", "urls": ["https://brazzers.com"], "parent_studio": "parent-uuid"}
+        changes = diff_studio_fields(local, upstream, None, {"name", "urls", "parent_studio"})
         assert len(changes) == 3
 
     def test_respects_enabled_fields_filter(self):
-        local = {"name": "Old", "url": "https://old.com", "parent_studio": None}
-        upstream = {"name": "New", "url": "https://new.com", "parent_studio": "uuid"}
-        snapshot = {"name": "Older", "url": "https://older.com", "parent_studio": None}
-        changes = diff_studio_fields(local, upstream, snapshot, {"url"})
+        local = {"name": "Old", "urls": ["https://old.com"], "parent_studio": None}
+        upstream = {"name": "New", "urls": ["https://new.com"], "parent_studio": "uuid"}
+        snapshot = {"name": "Older", "urls": ["https://older.com"], "parent_studio": None}
+        changes = diff_studio_fields(local, upstream, snapshot, {"urls"})
         assert len(changes) == 1
-        assert changes[0]["field"] == "url"
+        assert changes[0]["field"] == "urls"
 
     def test_empty_values_treated_as_equal(self):
-        local = {"url": None}
-        upstream = {"url": ""}
-        changes = diff_studio_fields(local, upstream, None, {"url"})
+        local = {"urls": []}
+        upstream = {"urls": []}
+        changes = diff_studio_fields(local, upstream, None, {"urls"})
         assert len(changes) == 0
 
     def test_parent_change_includes_display_names(self):
-        local = {"name": "Sub", "url": None, "parent_studio": None, "_parent_studio_name": None}
-        upstream = {"name": "Sub", "url": None, "parent_studio": "parent-uuid-1", "_parent_studio_name": "Brazzers"}
+        local = {"name": "Sub", "urls": [], "parent_studio": None, "_parent_studio_name": None}
+        upstream = {"name": "Sub", "urls": [], "parent_studio": "parent-uuid-1", "_parent_studio_name": "Brazzers"}
         changes = diff_studio_fields(local, upstream, None, {"parent_studio"})
         assert len(changes) == 1
         assert changes[0]["field"] == "parent_studio"
@@ -152,8 +184,8 @@ class TestDiffStudioFields:
 
     def test_parent_change_display_fallback_to_raw_value(self):
         """When no display name is available, display falls back to the raw value."""
-        local = {"name": "Sub", "url": None, "parent_studio": "old-uuid"}
-        upstream = {"name": "Sub", "url": None, "parent_studio": "new-uuid"}
+        local = {"name": "Sub", "urls": [], "parent_studio": "old-uuid"}
+        upstream = {"name": "Sub", "urls": [], "parent_studio": "new-uuid"}
         changes = diff_studio_fields(local, upstream, None, {"parent_studio"})
         assert len(changes) == 1
         assert changes[0]["local_display"] == "old-uuid"
@@ -161,8 +193,8 @@ class TestDiffStudioFields:
 
     def test_non_parent_fields_have_no_display_keys(self):
         """Only parent_studio gets display enrichment."""
-        local = {"name": "Old", "url": None, "parent_studio": None}
-        upstream = {"name": "New", "url": None, "parent_studio": None}
+        local = {"name": "Old", "urls": [], "parent_studio": None}
+        upstream = {"name": "New", "urls": [], "parent_studio": None}
         changes = diff_studio_fields(local, upstream, None, {"name"})
         assert len(changes) == 1
         assert "local_display" not in changes[0]
@@ -173,7 +205,7 @@ class TestBuildLocalStudioData:
         """Parent's stashbox ID should be used instead of local numeric ID."""
         studio = {
             "name": "Sub Studio",
-            "url": None,
+            "urls": [],
             "parent_studio": {
                 "id": "10",
                 "name": "Parent Studio",
@@ -190,7 +222,7 @@ class TestBuildLocalStudioData:
         """If parent has no stash_id for this endpoint, parent_studio is None."""
         studio = {
             "name": "Sub Studio",
-            "url": None,
+            "urls": [],
             "parent_studio": {
                 "id": "10",
                 "name": "Parent Studio",
@@ -207,7 +239,7 @@ class TestBuildLocalStudioData:
         """Parent with no stash_ids results in None parent_studio."""
         studio = {
             "name": "Sub Studio",
-            "url": None,
+            "urls": [],
             "parent_studio": {
                 "id": "10",
                 "name": "Parent Studio",
@@ -219,16 +251,36 @@ class TestBuildLocalStudioData:
         assert result["_parent_studio_name"] == "Parent Studio"
 
     def test_no_parent(self):
-        studio = {"name": "Studio", "url": "https://example.com", "parent_studio": None}
+        studio = {"name": "Studio", "urls": ["https://example.com"], "parent_studio": None}
         result = _build_local_studio_data(studio, "https://stashdb.org/graphql")
         assert result["parent_studio"] is None
         assert result["_parent_studio_name"] is None
+
+    def test_urls_from_local_studio(self):
+        """Local studio URLs should be passed through as array."""
+        studio = {
+            "name": "Studio",
+            "urls": ["https://example.com", "https://twitter.com/studio"],
+            "parent_studio": None,
+        }
+        result = _build_local_studio_data(studio, "https://stashdb.org/graphql")
+        assert result["urls"] == ["https://example.com", "https://twitter.com/studio"]
+
+    def test_empty_urls(self):
+        studio = {"name": "Studio", "urls": [], "parent_studio": None}
+        result = _build_local_studio_data(studio, "https://stashdb.org/graphql")
+        assert result["urls"] == []
+
+    def test_none_urls(self):
+        studio = {"name": "Studio", "parent_studio": None}
+        result = _build_local_studio_data(studio, "https://stashdb.org/graphql")
+        assert result["urls"] == []
 
     def test_parent_multiple_endpoints_picks_correct(self):
         """When parent is linked to multiple endpoints, picks the right one."""
         studio = {
             "name": "Sub",
-            "url": None,
+            "urls": [],
             "parent_studio": {
                 "id": "10",
                 "name": "Parent",


### PR DESCRIPTION
## Summary

- **Studio alias detection**: `_resolve_stashbox_studio_to_local` now checks aliases (not just primary name) when resolving upstream studios, preventing duplicate studio creation when a name is already used as an alias (e.g., "Jacquie et Michel" is an alias of "Jacquie & Michel TV")
- **Studio URLs as arrays**: Changed studio URL field from singular string to array throughout the pipeline — field mapper, analyzer, GraphQL queries, normalization, and studio creation. Studios can have multiple URLs (e.g., Vouyer Media has 4 on StashDB). Bumps studio `logic_version` to 5, triggering full re-analysis.
- **Performer name conflict auto-merge**: When renaming a performer causes a name conflict (e.g., renaming "Miss Kenzie Anne" to "Kenzie Anne" when a local "Kenzie Anne" already exists), the conflicting performer is automatically merged into the StashBox-linked destination performer, then the name update is retried.

## Test plan
- [x] All 992 existing tests pass
- [x] New tests for studio alias resolution (`test_update_studio_action.py`)
- [x] New tests for performer name conflict auto-merge (`test_update_performer_action.py`)
- [x] Updated studio field mapper tests for URL arrays
- [x] Updated studio analyzer tests for URL arrays
- [ ] Manual: Verify studio with alias name resolves correctly during upstream sync
- [ ] Manual: Verify multi-URL studios sync all URLs
- [ ] Manual: Verify performer rename with name conflict triggers auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)