### PR TITLE
fix: normalize URL trailing slashes, fix studio/scene alias_list handling

### DIFF
--- a/api/tests/test_upstream_field_mapper.py
+++ b/api/tests/test_upstream_field_mapper.py
@@ -220,6 +220,13 @@ class TestValuesEqual:
     def test_alias_list_case_insensitive(self):
         assert _values_equal(["Jane", "JD"], ["jane", "jd"], "alias_list") is True
 
+    def test_alias_list_trailing_slash_normalized(self):
+        assert _values_equal(
+            ["https://www.kink.com/"],
+            ["https://www.kink.com"],
+            "alias_list",
+        ) is True
+
     def test_alias_list_different_sets(self):
         assert _values_equal(["Jane"], ["Jane", "JD"], "alias_list") is False
 

--- a/api/upstream_field_mapper.py
+++ b/api/upstream_field_mapper.py
@@ -471,11 +471,11 @@ def _values_equal(local_value, upstream_value, merge_type: str) -> bool:
         return True
     if merge_type == "alias_list":
         local_set = {
-            v.lower() if isinstance(v, str) else v
+            v.lower().rstrip("/") if isinstance(v, str) else v
             for v in (local_value or [])
         }
         upstream_set = {
-            v.lower() if isinstance(v, str) else v
+            v.lower().rstrip("/") if isinstance(v, str) else v
             for v in (upstream_value or [])
         }
         return local_set == upstream_set


### PR DESCRIPTION
## Summary
- Normalize trailing slashes in URL comparison so `https://example.com/` and `https://example.com` are treated as equal (backend + frontend)
- Studio upstream detail now renders URLs with merged list UI (BOTH/LOCAL/UPSTREAM tags + checkboxes) matching the performer pattern
- Studio and scene apply handlers now properly handle `alias_list` merge type for URL fields

## Test plan
- [x] All 83 upstream field mapper tests pass
- [ ] Verify Kink studio no longer shows false URL diff
- [ ] Verify studio URL changes show merged list UI like performers
- [ ] Verify scene URL changes are properly collected on apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)