### PR TITLE
feat: add Dismiss All button to recommendation pages

### DIFF
--- a/api/recommendations_db.py
+++ b/api/recommendations_db.py
@@ -675,6 +675,38 @@ class RecommendationsDB:
 
             return True
 
+    def batch_dismiss_by_type(self, rec_type: str, permanent: bool = False, reason: Optional[str] = None) -> int:
+        """Dismiss all pending recommendations of a given type. Returns count dismissed."""
+        with self._connection() as conn:
+            # Get all pending recs of this type
+            rows = conn.execute(
+                "SELECT id, type, target_type, target_id FROM recommendations WHERE type = ? AND status = 'pending'",
+                (rec_type,)
+            ).fetchall()
+
+            if not rows:
+                return 0
+
+            rec_ids = [row['id'] for row in rows]
+
+            # Mark all as dismissed
+            conn.execute(
+                f"UPDATE recommendations SET status = 'dismissed', updated_at = datetime('now') WHERE id IN ({','.join('?' * len(rec_ids))})",
+                rec_ids
+            )
+
+            # Add to dismissed_targets
+            for row in rows:
+                try:
+                    conn.execute(
+                        "INSERT INTO dismissed_targets (type, target_type, target_id, reason, permanent) VALUES (?, ?, ?, ?, ?)",
+                        (row['type'], row['target_type'], row['target_id'], reason, int(permanent))
+                    )
+                except sqlite3.IntegrityError:
+                    pass  # Already dismissed
+
+            return len(rec_ids)
+
     def is_dismissed(self, type: str, target_type: str, target_id: str) -> bool:
         """Check if a target has been dismissed."""
         with self._connection() as conn:

--- a/api/recommendations_router.py
+++ b/api/recommendations_router.py
@@ -1523,3 +1523,21 @@ async def accept_all_fingerprint_matches(
     db = get_rec_db()
     accepted = await _accept_all_fingerprint_matches(stash, db, request.endpoint)
     return {"success": True, "accepted_count": accepted}
+
+
+class BatchDismissRequest(BaseModel):
+    """Request to batch dismiss all pending recommendations of a type."""
+    type: str = Field(..., description="Recommendation type to dismiss")
+    permanent: bool = Field(False, description="If true, never show these again")
+
+
+@router.post("/actions/batch-dismiss")
+async def batch_dismiss(request: BatchDismissRequest):
+    """Dismiss all pending recommendations of a given type."""
+    db = get_rec_db()
+    dismissed_count = db.batch_dismiss_by_type(
+        rec_type=request.type,
+        permanent=request.permanent,
+        reason="Batch dismissed by user",
+    )
+    return {"success": True, "dismissed_count": dismissed_count}

--- a/api/tests/test_batch_dismiss.py
+++ b/api/tests/test_batch_dismiss.py
@@ -1,0 +1,118 @@
+"""Tests for batch dismiss functionality."""
+
+import pytest
+from recommendations_db import RecommendationsDB
+
+
+class TestBatchDismissByType:
+    """Tests for RecommendationsDB.batch_dismiss_by_type()."""
+
+    @pytest.fixture
+    def db(self, tmp_path):
+        return RecommendationsDB(tmp_path / "test.db")
+
+    def _create_rec(self, db, rec_type, target_id, status="pending"):
+        """Helper to create a recommendation and optionally set its status."""
+        rec_id = db.create_recommendation(
+            type=rec_type,
+            target_type="performer",
+            target_id=target_id,
+            details={"test": True},
+        )
+        if status != "pending":
+            with db._connection() as conn:
+                conn.execute(
+                    "UPDATE recommendations SET status = ? WHERE id = ?",
+                    (status, rec_id),
+                )
+        return rec_id
+
+    def test_dismisses_all_pending_of_type(self, db):
+        """All pending recs of the specified type should be dismissed."""
+        self._create_rec(db, "upstream_performer_changes", "1")
+        self._create_rec(db, "upstream_performer_changes", "2")
+        self._create_rec(db, "upstream_performer_changes", "3")
+
+        count = db.batch_dismiss_by_type("upstream_performer_changes")
+        assert count == 3
+
+        recs = db.get_recommendations(type="upstream_performer_changes")
+        for rec in recs:
+            assert rec.status == "dismissed"
+
+    def test_does_not_affect_other_types(self, db):
+        """Recs of other types should remain untouched."""
+        self._create_rec(db, "upstream_performer_changes", "1")
+        tag_id = self._create_rec(db, "upstream_tag_changes", "2")
+
+        db.batch_dismiss_by_type("upstream_performer_changes")
+
+        tag_rec = db.get_recommendation(tag_id)
+        assert tag_rec.status == "pending"
+
+    def test_only_dismisses_pending(self, db):
+        """Already resolved/dismissed recs should not be affected."""
+        pending_id = self._create_rec(db, "upstream_performer_changes", "1")
+        resolved_id = self._create_rec(db, "upstream_performer_changes", "2", status="resolved")
+        dismissed_id = self._create_rec(db, "upstream_performer_changes", "3", status="dismissed")
+
+        count = db.batch_dismiss_by_type("upstream_performer_changes")
+        assert count == 1
+
+        assert db.get_recommendation(pending_id).status == "dismissed"
+        assert db.get_recommendation(resolved_id).status == "resolved"
+        assert db.get_recommendation(dismissed_id).status == "dismissed"
+
+    def test_temporary_dismiss_adds_to_dismissed_targets(self, db):
+        """Temporary dismiss should add to dismissed_targets with permanent=0."""
+        self._create_rec(db, "upstream_performer_changes", "1")
+
+        db.batch_dismiss_by_type("upstream_performer_changes", permanent=False)
+
+        assert db.is_dismissed("upstream_performer_changes", "performer", "1")
+        assert not db.is_permanently_dismissed("upstream_performer_changes", "performer", "1")
+
+    def test_permanent_dismiss_adds_permanent_target(self, db):
+        """Permanent dismiss should add to dismissed_targets with permanent=1."""
+        self._create_rec(db, "upstream_performer_changes", "1")
+
+        db.batch_dismiss_by_type("upstream_performer_changes", permanent=True)
+
+        assert db.is_permanently_dismissed("upstream_performer_changes", "performer", "1")
+
+    def test_returns_zero_when_no_pending(self, db):
+        """Should return 0 when no pending recs of type exist."""
+        self._create_rec(db, "upstream_performer_changes", "1", status="resolved")
+
+        count = db.batch_dismiss_by_type("upstream_performer_changes")
+        assert count == 0
+
+    def test_returns_zero_for_unknown_type(self, db):
+        """Should return 0 for a type with no recs at all."""
+        count = db.batch_dismiss_by_type("nonexistent_type")
+        assert count == 0
+
+    def test_stores_reason(self, db):
+        """Should store the dismiss reason in dismissed_targets."""
+        self._create_rec(db, "upstream_performer_changes", "1")
+
+        db.batch_dismiss_by_type("upstream_performer_changes", reason="Batch dismissed by user")
+
+        with db._connection() as conn:
+            row = conn.execute(
+                "SELECT reason FROM dismissed_targets WHERE target_id = '1'"
+            ).fetchone()
+            assert row["reason"] == "Batch dismissed by user"
+
+    def test_duplicate_dismissed_targets_ignored(self, db):
+        """If a target is already in dismissed_targets, should not fail."""
+        rec_id = self._create_rec(db, "upstream_performer_changes", "1")
+        # Dismiss individually first
+        db.dismiss_recommendation(rec_id)
+
+        # Re-create as pending (simulate re-analysis finding changes)
+        new_id = self._create_rec(db, "upstream_performer_changes", "1-new")
+
+        # Batch dismiss should still work
+        count = db.batch_dismiss_by_type("upstream_performer_changes")
+        assert count == 1

--- a/plugin/stash-sense-recommendations.js
+++ b/plugin/stash-sense-recommendations.js
@@ -155,6 +155,10 @@
       return apiCall('rec_dismiss_upstream', { rec_id: recId, reason, permanent: !!permanent });
     },
 
+    async batchDismiss(type, permanent) {
+      return apiCall('rec_batch_dismiss', { type, permanent: !!permanent });
+    },
+
     async searchEntities(entityType, query, endpoint) {
       return apiCall('rec_search_entities', { entity_type: entityType, query, endpoint });
     },
@@ -783,14 +787,19 @@
             Dismissed
           </button>
         </div>
-        ${currentState.status === 'pending' && (currentState.type === 'upstream_performer_changes' || currentState.type === 'upstream_tag_changes' || currentState.type === 'upstream_studio_changes')
-          ? '<button class="ss-accept-all-btn" id="ss-accept-all-btn">Accept All Changes</button>'
-          : ''
-        }
-        ${currentState.status === 'pending' && currentState.type === 'scene_fingerprint_match'
-          ? '<button class="ss-accept-all-btn" id="ss-accept-all-fp-btn">Accept All High-Confidence</button>'
-          : ''
-        }
+        ${currentState.status === 'pending' ? `
+        <div class="ss-list-actions">
+          ${currentState.type === 'upstream_performer_changes' || currentState.type === 'upstream_tag_changes' || currentState.type === 'upstream_studio_changes'
+            ? '<button class="ss-accept-all-btn" id="ss-accept-all-btn">Accept All Changes</button>'
+            : ''
+          }
+          ${currentState.type === 'scene_fingerprint_match'
+            ? '<button class="ss-accept-all-btn" id="ss-accept-all-fp-btn">Accept All High-Confidence</button>'
+            : ''
+          }
+          <button class="ss-dismiss-all-btn" id="ss-dismiss-all-btn">Dismiss All</button>
+        </div>
+        ` : ''}
       </div>
 
       <div class="ss-list-content">
@@ -888,6 +897,50 @@
           acceptAllFpBtn.classList.add('ss-btn-error');
           acceptAllFpBtn.disabled = false;
         }
+      });
+    }
+
+    // Dismiss All button
+    const dismissAllBtn = container.querySelector('#ss-dismiss-all-btn');
+    if (dismissAllBtn) {
+      dismissAllBtn.addEventListener('click', async () => {
+        // Show confirmation modal with permanent/temporary options
+        const overlay = document.createElement('div');
+        overlay.className = 'ss-modal-overlay';
+        overlay.innerHTML = `
+          <div class="ss-modal" style="max-width:420px;">
+            <h3>Dismiss All</h3>
+            <p style="margin:0.75rem 0;color:#aaa;">How would you like to dismiss all pending ${typeConfigs[currentState.type] || currentState.type} recommendations?</p>
+            <div style="display:flex;flex-direction:column;gap:0.5rem;margin-top:1rem;">
+              <button class="ss-btn ss-btn-secondary" id="ss-dismiss-temp">Dismiss until next analysis</button>
+              <button class="ss-btn ss-btn-danger" id="ss-dismiss-perm">Never show again</button>
+              <button class="ss-btn" id="ss-dismiss-cancel" style="margin-top:0.25rem;">Cancel</button>
+            </div>
+          </div>
+        `;
+        document.body.appendChild(overlay);
+
+        const handleDismiss = async (permanent) => {
+          overlay.querySelector('.ss-modal').innerHTML = '<div class="ss-loading-inline"><div class="ss-spinner"></div></div><p style="text-align:center;margin-top:0.5rem;">Dismissing...</p>';
+          try {
+            const result = await RecommendationsAPI.batchDismiss(currentState.type, permanent);
+            overlay.remove();
+            dismissAllBtn.textContent = `Dismissed ${result.dismissed_count}!`;
+            dismissAllBtn.disabled = true;
+            setTimeout(() => {
+              renderCurrentView(document.getElementById('ss-recommendations'));
+            }, 1500);
+          } catch (e) {
+            overlay.remove();
+            dismissAllBtn.textContent = `Failed: ${e.message}`;
+            setTimeout(() => { dismissAllBtn.textContent = 'Dismiss All'; dismissAllBtn.disabled = false; }, 2000);
+          }
+        };
+
+        overlay.querySelector('#ss-dismiss-temp').addEventListener('click', () => handleDismiss(false));
+        overlay.querySelector('#ss-dismiss-perm').addEventListener('click', () => handleDismiss(true));
+        overlay.querySelector('#ss-dismiss-cancel').addEventListener('click', () => overlay.remove());
+        overlay.addEventListener('click', (e) => { if (e.target === overlay) overlay.remove(); });
       });
     }
 

--- a/plugin/stash-sense.css
+++ b/plugin/stash-sense.css
@@ -1020,6 +1020,12 @@
 }
 
 /* Accept All button + modal styles */
+.ss-list-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
 .ss-accept-all-btn {
   padding: 8px 20px;
   background: #198754;
@@ -1038,6 +1044,30 @@
 }
 
 .ss-accept-all-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.ss-dismiss-all-btn {
+  padding: 8px 20px;
+  background: transparent;
+  color: #999;
+  border: 1px solid #555;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  white-space: nowrap;
+}
+
+.ss-dismiss-all-btn:hover:not(:disabled) {
+  background: rgba(220, 53, 69, 0.1);
+  color: #dc3545;
+  border-color: #dc3545;
+}
+
+.ss-dismiss-all-btn:disabled {
   opacity: 0.6;
   cursor: not-allowed;
 }

--- a/plugin/stash_sense_backend.py
+++ b/plugin/stash_sense_backend.py
@@ -510,6 +510,15 @@ def handle_recommendations(mode, args, sidecar_url):
             return {"error": "No rec_id provided"}
         return rec_dismiss(sidecar_url, rec_id, args.get("reason"))
 
+    elif mode == "rec_batch_dismiss":
+        rec_type = args.get("type")
+        if not rec_type:
+            return {"error": "No type provided"}
+        return sidecar_post(sidecar_url, "/recommendations/actions/batch-dismiss", {
+            "type": rec_type,
+            "permanent": args.get("permanent", False),
+        })
+
     elif mode == "rec_analysis_types":
         return rec_analysis_types(sidecar_url)
 


### PR DESCRIPTION
## Summary
- New `POST /recommendations/actions/batch-dismiss` endpoint with `type` and `permanent` params
- New `batch_dismiss_by_type()` DB method — dismisses all pending recs of a type, adds to `dismissed_targets`
- Muted "Dismiss All" button on list view header for all recommendation types (pending tab only)
- Confirmation modal with "Dismiss until next analysis" vs "Never show again" options
- Action buttons grouped in `.ss-list-actions` container for proper flex layout
- Backend proxy route `rec_batch_dismiss` added

Closes #73

## Test plan
- [ ] 9 new unit tests pass (`test_batch_dismiss.py`)
- [ ] Full test suite still passes (1017 existing + 9 new)
- [ ] Verify Dismiss All button appears on upstream performer/tag/studio/scene pages
- [ ] Verify Dismiss All button appears on duplicate performer/scene/file pages
- [ ] Verify Dismiss All button appears on fingerprint match page
- [ ] Verify temporary dismiss: recs return on next analysis
- [ ] Verify permanent dismiss: recs never return

🤖 Generated with [Claude Code](https://claude.com/claude-code)