### PR TITLE
fix: upstream performer merge conflict improvements

### DIFF
--- a/api/recommendations_router.py
+++ b/api/recommendations_router.py
@@ -927,7 +927,15 @@ async def _auto_merge_conflicting_performer(
         f"Auto-merging conflicting performer '{conflicting['name']}' "
         f"(ID: {conflicting['id']}) into performer {destination_id}"
     )
-    await stash.merge_performers([conflicting["id"]], destination_id)
+
+    try:
+        await stash.merge_performers([conflicting["id"]], destination_id)
+    except Exception as e:
+        err_msg = str(e).lower()
+        if "not found" in err_msg or "does not exist" in err_msg:
+            logger.warning(f"Conflicting performer {conflicting['id']} already deleted, skipping merge")
+            return {"merged_id": conflicting["id"], "merged_name": conflicting["name"]}
+        raise
 
     # Delete the now-orphaned source performer
     try:

--- a/api/tests/test_update_performer_action.py
+++ b/api/tests/test_update_performer_action.py
@@ -110,3 +110,90 @@ class TestPerformerNameConflictAutoMerge:
             })
 
             assert resp.status_code == 500
+
+    def test_deleted_conflicting_performer_skips_merge(self, app):
+        """If the conflicting performer was deleted, skip merge and proceed."""
+        with patch("recommendations_router.get_stash_client") as mock_get_stash:
+            mock_stash = MagicMock()
+
+            call_count = 0
+
+            async def mock_update_performer(performer_id, **fields):
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1 and "name" in fields:
+                    raise RuntimeError(
+                        'GraphQL error: Name "Test" already used by performer "Test"'
+                    )
+                return {"id": performer_id}
+
+            mock_stash.update_performer = AsyncMock(side_effect=mock_update_performer)
+
+            # search_performers finds the conflicting performer
+            mock_stash.search_performers = AsyncMock(return_value=[
+                {"id": "99", "name": "Test", "disambiguation": "", "alias_list": [], "stash_ids": []},
+            ])
+
+            # merge_performers fails because the performer was deleted
+            mock_stash.merge_performers = AsyncMock(
+                side_effect=RuntimeError("performer not found")
+            )
+
+            mock_stash.get_performer = AsyncMock(return_value={
+                "id": "50", "name": "Old Name", "alias_list": [], "stash_ids": [],
+            })
+
+            mock_get_stash.return_value = mock_stash
+
+            import recommendations_router
+            recommendations_router._entity_name_cache_loaded.clear()
+            recommendations_router._entity_name_cache.clear()
+
+            client = TestClient(app)
+            resp = client.post("/recommendations/actions/update-performer", json={
+                "performer_id": "50",
+                "fields": {"name": "Test"},
+            })
+
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["success"] is True
+            assert data.get("auto_merged") is True
+
+    def test_merge_raises_on_non_deleted_error(self, app):
+        """If merge fails for a reason other than 'not found', the error should propagate."""
+        with patch("recommendations_router.get_stash_client") as mock_get_stash:
+            mock_stash = MagicMock()
+
+            mock_stash.update_performer = AsyncMock(
+                side_effect=RuntimeError(
+                    'GraphQL error: Name "Test" already used by performer "Test"'
+                )
+            )
+
+            mock_stash.search_performers = AsyncMock(return_value=[
+                {"id": "99", "name": "Test", "disambiguation": "", "alias_list": [], "stash_ids": []},
+            ])
+
+            # merge_performers fails with a different error
+            mock_stash.merge_performers = AsyncMock(
+                side_effect=RuntimeError("internal server error")
+            )
+
+            mock_stash.get_performer = AsyncMock(return_value={
+                "id": "50", "name": "Old Name", "alias_list": [], "stash_ids": [],
+            })
+
+            mock_get_stash.return_value = mock_stash
+
+            import recommendations_router
+            recommendations_router._entity_name_cache_loaded.clear()
+            recommendations_router._entity_name_cache.clear()
+
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.post("/recommendations/actions/update-performer", json={
+                "performer_id": "50",
+                "fields": {"name": "Test"},
+            })
+
+            assert resp.status_code == 500

--- a/plugin/stash-sense-recommendations.js
+++ b/plugin/stash-sense-recommendations.js
@@ -1713,7 +1713,14 @@
         const conflicts = (nameCheck?.findPerformers?.performers || [])
           .filter(p => p.id !== performerId);
         if (conflicts.length > 0) {
-          nameConflict = conflicts[0];
+          const candidate = conflicts[0];
+          // Different disambiguation values mean different people — not a conflict
+          const candidateDisambig = (candidate.disambiguation || '').trim();
+          const proposedDisambigVal = (proposedDisambig || '').trim();
+          const isDistinctPerson = candidateDisambig && proposedDisambigVal && candidateDisambig !== proposedDisambigVal;
+          if (!isDistinctPerson) {
+            nameConflict = candidate;
+          }
         }
       } catch (e) {
         console.warn('[Stash Sense] Name uniqueness check failed:', e);
@@ -1747,31 +1754,45 @@
   }
 
 
-  function showNameConflictDialog(performerId, conflictingPerformer, onMerge, onCancel) {
+  function showNameConflictDialog(performerId, conflictingPerformer, onMerge, onCancel, currentPerformer) {
     const overlay = document.createElement('div');
     overlay.className = 'ss-modal-overlay';
     overlay.style.zIndex = '10001';
 
     const c = conflictingPerformer;
-    const disambigText = c.disambiguation ? ` (${c.disambiguation})` : '';
+    const cur = currentPerformer || {};
 
     overlay.innerHTML = `
-      <div class="ss-modal" style="max-width: 480px;">
+      <div class="ss-modal" style="max-width: 600px;">
         <div class="ss-modal-header">
           <h3>Name Conflict</h3>
           <button class="ss-modal-close" data-action="close">&times;</button>
         </div>
         <div class="ss-modal-body" style="padding: 16px;">
-          <p style="margin: 0 0 12px;">
-            A performer named <strong>${escapeHtml(c.name)}${escapeHtml(disambigText)}</strong> already exists
-            (ID: ${escapeHtml(c.id)}, ${c.scene_count || 0} scenes).
+          <p style="margin: 0 0 12px; color: var(--ss-text-muted);">
+            A performer with this name already exists. You can merge the duplicate into this performer
+            (scenes will be reassigned and the duplicate deleted), or skip this conflict.
           </p>
-          <p style="margin: 0 0 16px; color: var(--ss-text-muted);">
-            You can merge the duplicate into this performer (content will be reassigned and the duplicate deleted),
-            or open both performers to resolve manually.
-          </p>
-          <div style="display: flex; gap: 8px; justify-content: flex-end;">
-            <button class="ss-btn" data-action="open-both">Open Both</button>
+          <div class="ss-conflict-comparison">
+            <div class="ss-conflict-card">
+              <div class="ss-conflict-card-label">This Performer</div>
+              <img src="${escapeHtml(cur.image_path || '')}" class="ss-conflict-thumb" onerror="this.style.display='none'" />
+              <div class="ss-conflict-name">${escapeHtml(cur.name || 'Unknown')}</div>
+              ${cur.disambiguation ? `<div class="ss-conflict-disambig">${escapeHtml(cur.disambiguation)}</div>` : ''}
+              <div class="ss-conflict-meta">ID: ${escapeHtml(String(performerId))}</div>
+              <a href="/performers/${performerId}" target="_blank" class="ss-conflict-link">View in Stash</a>
+            </div>
+            <div class="ss-conflict-card">
+              <div class="ss-conflict-card-label">Conflicting Performer</div>
+              <img src="${escapeHtml(c.image_path || '')}" class="ss-conflict-thumb" onerror="this.style.display='none'" />
+              <div class="ss-conflict-name">${escapeHtml(c.name)}</div>
+              ${c.disambiguation ? `<div class="ss-conflict-disambig">${escapeHtml(c.disambiguation)}</div>` : ''}
+              <div class="ss-conflict-meta">ID: ${escapeHtml(c.id)} &middot; ${c.scene_count || 0} scenes</div>
+              <a href="/performers/${c.id}" target="_blank" class="ss-conflict-link">View in Stash</a>
+            </div>
+          </div>
+          <div style="display: flex; gap: 8px; justify-content: flex-end; margin-top: 16px;">
+            <button class="ss-btn" data-action="skip">Skip</button>
             <button class="ss-btn ss-btn-primary" data-action="merge">Merge &amp; Continue</button>
           </div>
         </div>
@@ -1785,12 +1806,7 @@
 
     overlay.addEventListener('click', (e) => {
       const action = e.target.dataset?.action || e.target.closest('[data-action]')?.dataset?.action;
-      if (action === 'close') {
-        closeDialog();
-        onCancel();
-      } else if (action === 'open-both') {
-        window.open(`/performers/${performerId}`, '_blank');
-        window.open(`/performers/${c.id}`, '_blank');
+      if (action === 'close' || action === 'skip') {
         closeDialog();
         onCancel();
       } else if (action === 'merge') {
@@ -2119,7 +2135,12 @@
       applyBtn.textContent = 'Validating...';
 
       const proposedName = fields.name || details.performer_name;
-      const proposedDisambig = fields.disambiguation || null;
+      // Get disambiguation: from accepted fields first, then from the current local value in changes
+      let proposedDisambig = fields.disambiguation || null;
+      if (!proposedDisambig) {
+        const disambigChange = changes.find(c => c.field === 'disambiguation');
+        if (disambigChange) proposedDisambig = disambigChange.local_value || null;
+      }
       const proposedAliases = fields.aliases || fields._alias_add || [];
 
       const { errors: validationErrors, nameConflict } = await validatePerformerMerge(
@@ -2146,6 +2167,20 @@
             errorDiv.style.display = 'none';
             try {
               await RecommendationsAPI.mergePerformers(performerId, [conflictId]);
+            } catch (mergeErr) {
+              const msg = String(mergeErr.message || mergeErr);
+              // If the conflicting performer was already deleted, the merge is unnecessary — proceed
+              if (msg.includes('not found') || msg.includes('does not exist') || msg.includes('404')) {
+                console.warn('[Stash Sense] Conflicting performer already deleted, skipping merge');
+              } else {
+                errorDiv.innerHTML = `<div>Merge failed: ${escapeHtml(msg)}</div>`;
+                errorDiv.style.display = 'block';
+                applyBtn.textContent = 'Apply Selected Changes';
+                applyBtn.disabled = false;
+                return;
+              }
+            }
+            try {
               await RecommendationsAPI.updatePerformer(performerId, fields);
               await RecommendationsAPI.resolve(rec.id, 'applied', { fields, auto_merged: conflictId });
               applyBtn.textContent = 'Merged & Applied!';
@@ -2155,14 +2190,15 @@
                 currentState.selectedRec = null;
                 renderCurrentView(document.getElementById('ss-recommendations'));
               }, 1500);
-            } catch (mergeErr) {
-              errorDiv.innerHTML = `<div>${escapeHtml(mergeErr.message)}</div>`;
+            } catch (updateErr) {
+              errorDiv.innerHTML = `<div>${escapeHtml(updateErr.message)}</div>`;
               errorDiv.style.display = 'block';
               applyBtn.textContent = 'Apply Selected Changes';
               applyBtn.disabled = false;
             }
           },
-          () => { /* User chose cancel/open-both */ }
+          () => { /* User chose skip */ },
+          { name: details.performer_name, image_path: details.performer_image_path, disambiguation: proposedDisambig }
         );
         return;
       }

--- a/plugin/stash-sense.css
+++ b/plugin/stash-sense.css
@@ -1819,6 +1819,68 @@
   white-space: nowrap;
 }
 
+/* Name conflict comparison */
+.ss-conflict-comparison {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.ss-conflict-card {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--bs-border-color, #333);
+  border-radius: 8px;
+  padding: 12px;
+  text-align: center;
+}
+
+.ss-conflict-card-label {
+  font-size: 0.75rem;
+  color: #888;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 8px;
+}
+
+.ss-conflict-thumb {
+  width: 80px;
+  height: 80px;
+  object-fit: cover;
+  border-radius: 50%;
+  margin-bottom: 8px;
+}
+
+.ss-conflict-name {
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--bs-body-color, #fff);
+}
+
+.ss-conflict-disambig {
+  font-size: 0.85rem;
+  color: #888;
+  margin-top: 2px;
+}
+
+.ss-conflict-meta {
+  font-size: 0.8rem;
+  color: #666;
+  margin-top: 4px;
+}
+
+.ss-conflict-link {
+  font-size: 0.8rem;
+  color: var(--ss-accent, #6366f1);
+  text-decoration: none;
+  margin-top: 6px;
+  display: inline-block;
+}
+
+.ss-conflict-link:hover {
+  text-decoration: underline;
+}
+
 /* Detail view styles */
 .ss-upstream-header {
   display: flex;


### PR DESCRIPTION
## Summary
Three fixes to the upstream performer name conflict / merge dialog:

- **Disambiguation false positives**: Skip conflict dialog when both performers have different non-empty disambiguation values (e.g., "Felony 7697" vs "Felony 2241" are different people). Falls back to local disambiguation from changes array when field isn't being modified.
- **Deleted performer handling**: Backend catches "not found" errors during merge and proceeds with name update. Frontend also handles merge failures gracefully.
- **Inline comparison**: Replaces "Open Both" (two browser tabs) with side-by-side comparison panel showing images, names, disambiguation, scene counts, and "View in Stash" links. "Skip" replaces "Open Both" as the cancel action.

Closes #72

## Test plan
- [ ] 4 backend tests pass (`test_update_performer_action.py`)
- [ ] Verify disambiguation check: same name + different disambig = no conflict dialog
- [ ] Verify disambiguation check: same name + same/empty disambig = conflict dialog shown
- [ ] Verify deleted performer: merge proceeds gracefully if conflicting performer was deleted
- [ ] Verify inline comparison shows both performers side-by-side with images and details
- [ ] Verify "Skip" button closes dialog without action
- [ ] Verify "Merge & Continue" still merges and applies changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)