### PR TITLE
fix: return 409 with clear message for disambiguation-blocked merges

### DIFF
--- a/api/recommendations_router.py
+++ b/api/recommendations_router.py
@@ -884,6 +884,16 @@ async def update_performer_fields(request: UpdatePerformerRequest, entity_type: 
                 stash, performer_id, fields["name"],
                 destination_disambiguation=dest_disambig,
             )
+            if merged and merged.get("blocked_by_disambiguation"):
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        "Name conflict: a performer with this name exists but has a "
+                        "different disambiguation — they are different people and "
+                        "cannot be auto-merged. Use 'Update Fields Only' to apply "
+                        "other changes without the name."
+                    ),
+                )
             if merged:
                 # Retry the update after merging the conflicting performer
                 try:
@@ -918,10 +928,14 @@ async def _auto_merge_conflicting_performer(
     auto-merging them is never safe. Only merges when neither has disambiguation
     (i.e. they're truly duplicates with the same unqualified name).
 
-    Returns dict with merged_id and merged_name, or None if no match found.
+    Returns:
+        dict with merged_id/merged_name on success,
+        dict with blocked_by_disambiguation=True when skipped due to disambiguation,
+        or None if no matching performer found.
     """
     matches = await stash.search_performers(conflicting_name, limit=10)
     conflicting = None
+    blocked_by_disambiguation = False
     name_lower = conflicting_name.strip().lower()
     dest_disambig = (destination_disambiguation or "").strip().lower()
     for match in matches:
@@ -937,11 +951,14 @@ async def _auto_merge_conflicting_performer(
                     f"(dest='{dest_disambig}', match='{match_disambig}') "
                     f"for performer '{conflicting_name}'"
                 )
+                blocked_by_disambiguation = True
                 continue
             conflicting = match
             break
 
     if not conflicting:
+        if blocked_by_disambiguation:
+            return {"blocked_by_disambiguation": True}
         return None
 
     logger.warning(

--- a/api/tests/test_update_performer_action.py
+++ b/api/tests/test_update_performer_action.py
@@ -214,7 +214,8 @@ class TestDisambiguationMergeSafety:
     marked as distinct people sharing a name."""
 
     def test_skips_merge_when_both_have_different_disambiguations(self, app):
-        """'Hazel Grace (US)' and 'Hazel Grace (Russian)' should NOT merge."""
+        """'Hazel Grace (US)' and 'Hazel Grace (Russian)' should NOT merge.
+        Returns 409 with disambiguation-specific message."""
         with patch("recommendations_router.get_stash_client") as mock_get_stash:
             mock_stash = _make_mock_stash(
                 dest_disambig="US",
@@ -236,11 +237,13 @@ class TestDisambiguationMergeSafety:
                 "fields": {"name": "Hazel Grace"},
             })
 
-            assert resp.status_code == 500
+            assert resp.status_code == 409
+            assert "different disambiguation" in resp.json()["detail"]
             mock_stash.merge_performers.assert_not_called()
 
     def test_skips_merge_when_only_destination_has_disambiguation(self, app):
-        """'Hazel Grace (US)' should not merge with plain 'Hazel Grace'."""
+        """'Hazel Grace (US)' should not merge with plain 'Hazel Grace'.
+        Returns 409 with disambiguation-specific message."""
         with patch("recommendations_router.get_stash_client") as mock_get_stash:
             mock_stash = _make_mock_stash(
                 dest_disambig="US",
@@ -261,11 +264,13 @@ class TestDisambiguationMergeSafety:
                 "fields": {"name": "Hazel Grace"},
             })
 
-            assert resp.status_code == 500
+            assert resp.status_code == 409
+            assert "different disambiguation" in resp.json()["detail"]
             mock_stash.merge_performers.assert_not_called()
 
     def test_skips_merge_when_only_conflict_has_disambiguation(self, app):
-        """Plain 'Hazel Grace' should not auto-merge 'Hazel Grace (Russian)'."""
+        """Plain 'Hazel Grace' should not auto-merge 'Hazel Grace (Russian)'.
+        Returns 409 with disambiguation-specific message."""
         with patch("recommendations_router.get_stash_client") as mock_get_stash:
             mock_stash = _make_mock_stash(
                 dest_disambig="",
@@ -286,7 +291,8 @@ class TestDisambiguationMergeSafety:
                 "fields": {"name": "Hazel Grace"},
             })
 
-            assert resp.status_code == 500
+            assert resp.status_code == 409
+            assert "different disambiguation" in resp.json()["detail"]
             mock_stash.merge_performers.assert_not_called()
 
     def test_allows_merge_when_neither_has_disambiguation(self, app):
@@ -314,7 +320,8 @@ class TestDisambiguationMergeSafety:
 
     def test_uses_disambiguation_from_fields_over_current(self, app):
         """When fields dict includes disambiguation, it should be used for the
-        merge safety check (it's what the performer will become)."""
+        merge safety check (it's what the performer will become).
+        Returns 409 with disambiguation-specific message."""
         with patch("recommendations_router.get_stash_client") as mock_get_stash:
             mock_stash = _make_mock_stash(
                 dest_name="Hazel Grace",
@@ -338,5 +345,6 @@ class TestDisambiguationMergeSafety:
                 "fields": {"name": "Hazel Grace", "disambiguation": "US"},
             })
 
-            assert resp.status_code == 500
+            assert resp.status_code == 409
+            assert "different disambiguation" in resp.json()["detail"]
             mock_stash.merge_performers.assert_not_called()

--- a/plugin/stash-sense-recommendations.js
+++ b/plugin/stash-sense-recommendations.js
@@ -2342,7 +2342,9 @@
         }, 1500);
       } catch (e) {
         let errorMsg = e.message;
-        if (errorMsg.includes('duplicate') || errorMsg.includes('alias')) {
+        if (errorMsg.includes('different disambiguation') || errorMsg.includes('cannot be auto-merged')) {
+          errorMsg = 'Name conflict: a performer with this name has a different disambiguation — they are different people. Use "Update Fields Only" to apply other changes without the name.';
+        } else if (errorMsg.includes('duplicate') || errorMsg.includes('alias')) {
           errorMsg = `Alias conflict: ${errorMsg}. Try removing duplicate aliases.`;
         }
         errorDiv.innerHTML = `<div>${escapeHtml(errorMsg)}</div>`;


### PR DESCRIPTION
## Summary
- When a performer name update triggers a conflict and auto-merge is blocked by disambiguation, return a **409** with a clear, actionable message instead of an opaque 500
- Backend `_auto_merge_conflicting_performer` now returns a structured result distinguishing "blocked by disambiguation" from "no match found"
- Frontend detects the disambiguation-specific error and shows user-friendly guidance: "Use 'Update Fields Only' to apply other changes without the name"

## Test plan
- [x] All 4 disambiguation safety tests updated to expect 409 + message body assertion
- [x] Full test suite passes (1052 passed, 1 skipped)

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)