### PR TITLE
fix: wire run_id through AnalysisJob, fix duplicate scene detection

### DIFF
--- a/api/analyzers/base.py
+++ b/api/analyzers/base.py
@@ -6,7 +6,7 @@ All analyzers inherit from this class and implement the run() method.
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Optional, TYPE_CHECKING
+from typing import Callable, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..stash_client_unified import StashClientUnified
@@ -47,16 +47,32 @@ class BaseAnalyzer(ABC):
         self.stash = stash
         self.rec_db = rec_db
         self.run_id = run_id
+        self._items_total: Optional[int] = None
+        self._stop_requested = False
+        self._job_progress_callback: Optional[Callable[[int, Optional[int]], None]] = None
 
     def set_items_total(self, total: int):
         """Report total items to process for this run."""
+        self._items_total = total
         if self.run_id is not None:
             self.rec_db.update_analysis_items_total(self.run_id, total)
+        if self._job_progress_callback:
+            self._job_progress_callback(0, total)
 
     def update_progress(self, items_processed: int, recommendations_created: int):
         """Report progress for this run."""
         if self.run_id is not None:
             self.rec_db.update_analysis_progress(self.run_id, items_processed, recommendations_created)
+        if self._job_progress_callback:
+            self._job_progress_callback(items_processed, self._items_total)
+
+    def request_stop(self):
+        """Signal that this analyzer should stop at its next checkpoint."""
+        self._stop_requested = True
+
+    def is_stop_requested(self) -> bool:
+        """Check whether a stop has been requested."""
+        return self._stop_requested
 
     @abstractmethod
     async def run(self, incremental: bool = True) -> AnalysisResult:

--- a/api/analyzers/duplicate_scenes.py
+++ b/api/analyzers/duplicate_scenes.py
@@ -117,6 +117,11 @@ class DuplicateScenesAnalyzer(BaseAnalyzer):
         Phase 1: Generate candidate pairs from three sources.
         Returns total number of unique candidates.
         """
+        # Clean up orphaned candidates from previous broken runs (NULL run_id)
+        orphans = self.rec_db.clear_orphaned_candidates()
+        if orphans:
+            logger.warning(f"Cleaned up {orphans} orphaned candidates (NULL run_id)")
+
         # Clear any stale candidates from a previous failed run
         self.rec_db.clear_candidates(run_id)
 
@@ -232,6 +237,10 @@ class DuplicateScenesAnalyzer(BaseAnalyzer):
         last_id = 0
 
         while True:
+            if self.is_stop_requested():
+                logger.warning(f"Stop requested after scoring {scored} candidates")
+                break
+
             batch = self.rec_db.get_candidates_batch(run_id, after_id=last_id, limit=100)
             if not batch:
                 break
@@ -267,6 +276,11 @@ class DuplicateScenesAnalyzer(BaseAnalyzer):
 
                 scored += 1
                 last_id = candidate["id"]
+
+                # Periodic progress logging (every 500 scored)
+                if scored % 500 == 0:
+                    total = self._items_total or "?"
+                    logger.warning(f"Scoring progress: {scored}/{total} scored, {created} recommendations")
 
             self.update_progress(scored, created)
             await asyncio.sleep(0)

--- a/api/jobs/analysis_jobs.py
+++ b/api/jobs/analysis_jobs.py
@@ -1,10 +1,13 @@
 """Wraps existing analyzers as BaseJob subclasses."""
 from __future__ import annotations
 
+import logging
 from typing import Optional
 
 from base_job import BaseJob, JobContext
 from recommendations_router import ANALYZERS, get_rec_db, get_stash_client
+
+logger = logging.getLogger(__name__)
 
 
 class AnalysisJob(BaseJob):
@@ -23,11 +26,35 @@ class AnalysisJob(BaseJob):
         if not analyzer_class:
             raise ValueError(f"Unknown analyzer type: {self._type_id}")
 
-        analyzer = analyzer_class(stash, db, run_id=None)
-        result = await analyzer.run(incremental=True)
+        # Create a real analysis_runs entry (FK target for duplicate_candidates.run_id)
+        run_id = db.start_analysis_run(self._type_id)
+        logger.warning("Starting analysis job %s (run_id=%d, job_id=%d)", self._type_id, run_id, context.job_id)
 
-        await context.report_progress(
-            result.items_processed,
-            result.items_processed,
-        )
+        # Bridge progress from analyzer → job queue for frontend polling
+        def progress_callback(items_processed: int, items_total: Optional[int]) -> None:
+            import asyncio
+            loop = asyncio.get_event_loop()
+            loop.create_task(context.report_progress(items_processed, items_total))
+
+        analyzer = analyzer_class(stash, db, run_id=run_id)
+        analyzer._job_progress_callback = progress_callback
+
+        # Wire stop signal from job context to analyzer
+        if context.is_stop_requested():
+            analyzer.request_stop()
+
+        try:
+            result = await analyzer.run(incremental=True)
+
+            db.complete_analysis_run(run_id, result.recommendations_created)
+            await context.report_progress(result.items_processed, result.items_processed)
+            logger.warning(
+                "Analysis job %s completed (run_id=%d): %d processed, %d recommendations",
+                self._type_id, run_id, result.items_processed, result.recommendations_created,
+            )
+        except Exception:
+            db.fail_analysis_run(run_id, "Analysis job failed with exception")
+            logger.warning("Analysis job %s failed (run_id=%d)", self._type_id, run_id, exc_info=True)
+            raise
+
         return None

--- a/api/recommendations_db.py
+++ b/api/recommendations_db.py
@@ -1603,6 +1603,15 @@ class RecommendationsDB:
             )
             return cursor.rowcount
 
+    def clear_orphaned_candidates(self) -> int:
+        """Delete candidates with NULL run_id (from broken runs that passed run_id=None).
+        Returns count deleted."""
+        with self._connection() as conn:
+            cursor = conn.execute(
+                "DELETE FROM duplicate_candidates WHERE run_id IS NULL"
+            )
+            return cursor.rowcount
+
     def get_candidate_scene_ids(self, run_id: int) -> set[int]:
         """Get all distinct scene IDs that appear in candidates for a run."""
         with self._connection() as conn:

--- a/api/recommendations_router.py
+++ b/api/recommendations_router.py
@@ -32,6 +32,10 @@ def init_recommendations(db_path: str, stash_url: str, stash_api_key: str):
     stale = rec_db.fail_stale_analysis_runs()
     if stale:
         logger.warning("Marked %d stale analysis run(s) as failed", stale)
+    # Clean up orphaned candidates from broken runs that passed run_id=None
+    orphans = rec_db.clear_orphaned_candidates()
+    if orphans:
+        logger.warning("Cleaned up %d orphaned duplicate candidates (NULL run_id)", orphans)
     if stash_url:
         stash_client = StashClientUnified(stash_url, stash_api_key)
 

--- a/api/tests/test_duplicate_scenes_analyzer.py
+++ b/api/tests/test_duplicate_scenes_analyzer.py
@@ -1,7 +1,8 @@
 """Tests for DuplicateScenesAnalyzer."""
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock
+import sqlite3
+from unittest.mock import AsyncMock, MagicMock, patch
 
 
 class TestDuplicateScenesAnalyzer:
@@ -556,3 +557,256 @@ class TestCandidateGeneration:
         count = await analyzer._generate_candidates(run_id)
 
         assert count == 1
+
+
+class TestAnalysisJobRunId:
+    """Verify AnalysisJob creates a real analysis_runs entry and passes it to the analyzer."""
+
+    @pytest.fixture
+    def db(self, tmp_path):
+        from recommendations_db import RecommendationsDB
+        return RecommendationsDB(tmp_path / "test.db")
+
+    @pytest.fixture
+    def mock_stash(self):
+        stash = MagicMock()
+        stash.get_scenes_for_fingerprinting = AsyncMock(return_value=([], 0))
+        return stash
+
+    @pytest.mark.asyncio
+    async def test_analysis_job_creates_run_id(self, db, mock_stash):
+        """AnalysisJob should create an analysis_runs entry and pass it to the analyzer."""
+        from jobs.analysis_jobs import AnalysisJob
+        from base_job import JobContext
+
+        # Set up module-level globals used by AnalysisJob
+        with patch("jobs.analysis_jobs.get_rec_db", return_value=db), \
+             patch("jobs.analysis_jobs.get_stash_client", return_value=mock_stash), \
+             patch("jobs.analysis_jobs.ANALYZERS") as mock_analyzers:
+
+            # Track what run_id was passed to the analyzer
+            captured_run_id = None
+
+            class FakeAnalyzer:
+                type = "test_type"
+                _job_progress_callback = None
+
+                def __init__(self, stash, rec_db, run_id=None):
+                    nonlocal captured_run_id
+                    captured_run_id = run_id
+
+                def request_stop(self):
+                    pass
+
+                async def run(self, incremental=True):
+                    from analyzers.base import AnalysisResult
+                    return AnalysisResult(items_processed=5, recommendations_created=2)
+
+            mock_analyzers.get.return_value = FakeAnalyzer
+
+            job = AnalysisJob("test_type")
+            job_id = db.submit_job("test_type", priority=50, triggered_by="test")
+            db.start_job(job_id)
+            ctx = JobContext(job_id, db, None)
+
+            await job.run(ctx)
+
+            # run_id should be a real integer, not None
+            assert captured_run_id is not None
+            assert isinstance(captured_run_id, int)
+
+            # analysis_runs entry should exist and be completed
+            run = db.get_analysis_run(captured_run_id)
+            assert run is not None
+            assert run.status == "completed"
+            assert run.recommendations_created == 2
+
+    @pytest.mark.asyncio
+    async def test_analysis_job_marks_run_failed_on_exception(self, db, mock_stash):
+        """AnalysisJob should mark the analysis_run as failed if the analyzer raises."""
+        from jobs.analysis_jobs import AnalysisJob
+        from base_job import JobContext
+
+        with patch("jobs.analysis_jobs.get_rec_db", return_value=db), \
+             patch("jobs.analysis_jobs.get_stash_client", return_value=mock_stash), \
+             patch("jobs.analysis_jobs.ANALYZERS") as mock_analyzers:
+
+            captured_run_id = None
+
+            class FailingAnalyzer:
+                type = "test_type"
+                _job_progress_callback = None
+
+                def __init__(self, stash, rec_db, run_id=None):
+                    nonlocal captured_run_id
+                    captured_run_id = run_id
+
+                def request_stop(self):
+                    pass
+
+                async def run(self, incremental=True):
+                    raise RuntimeError("Test failure")
+
+            mock_analyzers.get.return_value = FailingAnalyzer
+
+            job = AnalysisJob("test_type")
+            job_id = db.submit_job("test_type", priority=50, triggered_by="test")
+            db.start_job(job_id)
+            ctx = JobContext(job_id, db, None)
+
+            with pytest.raises(RuntimeError):
+                await job.run(ctx)
+
+            # analysis_runs entry should be marked as failed
+            run = db.get_analysis_run(captured_run_id)
+            assert run is not None
+            assert run.status == "failed"
+
+
+class TestOrphanedCandidateCleanup:
+    """Verify NULL-run_id candidates are cleaned up and don't block new inserts."""
+
+    @pytest.fixture
+    def db(self, tmp_path):
+        from recommendations_db import RecommendationsDB
+        return RecommendationsDB(tmp_path / "test.db")
+
+    def test_clear_orphaned_candidates_removes_null_run_id(self, db):
+        """Candidates with NULL run_id should be deleted."""
+        # Insert orphaned candidates (simulating the old broken behavior)
+        with db._connection() as conn:
+            conn.execute(
+                "INSERT INTO duplicate_candidates (scene_a_id, scene_b_id, source, run_id) VALUES (1, 2, 'stashbox', NULL)"
+            )
+            conn.execute(
+                "INSERT INTO duplicate_candidates (scene_a_id, scene_b_id, source, run_id) VALUES (3, 4, 'face', NULL)"
+            )
+
+        deleted = db.clear_orphaned_candidates()
+        assert deleted == 2
+
+        # Table should be empty
+        with db._connection() as conn:
+            count = conn.execute("SELECT COUNT(*) FROM duplicate_candidates").fetchone()[0]
+            assert count == 0
+
+    def test_clear_orphaned_preserves_valid_candidates(self, db):
+        """Candidates with a real run_id should NOT be deleted."""
+        run_id = db.start_analysis_run("duplicate_scenes")
+        db.insert_candidate(1, 2, "stashbox", run_id)
+
+        # Insert an orphan too
+        with db._connection() as conn:
+            conn.execute(
+                "INSERT INTO duplicate_candidates (scene_a_id, scene_b_id, source, run_id) VALUES (3, 4, 'face', NULL)"
+            )
+
+        deleted = db.clear_orphaned_candidates()
+        assert deleted == 1
+
+        # Valid candidate should remain
+        assert db.count_candidates(run_id) == 1
+
+    def test_orphaned_candidates_block_new_inserts(self, db):
+        """NULL-run_id rows with same scene pair should block new INSERT (UNIQUE constraint)."""
+        with db._connection() as conn:
+            conn.execute(
+                "INSERT INTO duplicate_candidates (scene_a_id, scene_b_id, source, run_id) VALUES (1, 2, 'stashbox', NULL)"
+            )
+
+        # New insert with real run_id should fail due to UNIQUE(scene_a_id, scene_b_id)
+        run_id = db.start_analysis_run("duplicate_scenes")
+        result = db.insert_candidate(1, 2, "stashbox", run_id)
+        assert result is None  # Blocked by existing orphan
+
+        # After cleanup, the insert should succeed
+        db.clear_orphaned_candidates()
+        result = db.insert_candidate(1, 2, "stashbox", run_id)
+        assert result is not None
+
+    def test_clear_orphaned_returns_zero_when_none(self, db):
+        """Should return 0 when no orphaned candidates exist."""
+        deleted = db.clear_orphaned_candidates()
+        assert deleted == 0
+
+
+class TestProgressBridge:
+    """Verify progress callback bridges from BaseAnalyzer to job context."""
+
+    @pytest.fixture
+    def db(self, tmp_path):
+        from recommendations_db import RecommendationsDB
+        return RecommendationsDB(tmp_path / "test.db")
+
+    def test_set_items_total_fires_callback(self, db):
+        """set_items_total should fire the progress callback with (0, total)."""
+        from analyzers.base import BaseAnalyzer
+
+        class ConcreteAnalyzer(BaseAnalyzer):
+            type = "test"
+            async def run(self, incremental=True):
+                pass
+
+        run_id = db.start_analysis_run("test")
+        analyzer = ConcreteAnalyzer(MagicMock(), db, run_id=run_id)
+
+        callback_calls = []
+        analyzer._job_progress_callback = lambda processed, total: callback_calls.append((processed, total))
+
+        analyzer.set_items_total(100)
+
+        assert len(callback_calls) == 1
+        assert callback_calls[0] == (0, 100)
+        assert analyzer._items_total == 100
+
+    def test_update_progress_fires_callback(self, db):
+        """update_progress should fire the progress callback with (items_processed, _items_total)."""
+        from analyzers.base import BaseAnalyzer
+
+        class ConcreteAnalyzer(BaseAnalyzer):
+            type = "test"
+            async def run(self, incremental=True):
+                pass
+
+        run_id = db.start_analysis_run("test")
+        analyzer = ConcreteAnalyzer(MagicMock(), db, run_id=run_id)
+
+        callback_calls = []
+        analyzer._job_progress_callback = lambda processed, total: callback_calls.append((processed, total))
+
+        analyzer.set_items_total(100)
+        analyzer.update_progress(50, 3)
+
+        assert len(callback_calls) == 2
+        assert callback_calls[1] == (50, 100)
+
+    def test_stop_signal(self, db):
+        """is_stop_requested should reflect request_stop calls."""
+        from analyzers.base import BaseAnalyzer
+
+        class ConcreteAnalyzer(BaseAnalyzer):
+            type = "test"
+            async def run(self, incremental=True):
+                pass
+
+        analyzer = ConcreteAnalyzer(MagicMock(), db)
+
+        assert not analyzer.is_stop_requested()
+        analyzer.request_stop()
+        assert analyzer.is_stop_requested()
+
+    def test_no_callback_no_error(self, db):
+        """set_items_total and update_progress should work without a callback set."""
+        from analyzers.base import BaseAnalyzer
+
+        class ConcreteAnalyzer(BaseAnalyzer):
+            type = "test"
+            async def run(self, incremental=True):
+                pass
+
+        run_id = db.start_analysis_run("test")
+        analyzer = ConcreteAnalyzer(MagicMock(), db, run_id=run_id)
+
+        # Should not raise
+        analyzer.set_items_total(100)
+        analyzer.update_progress(50, 3)

--- a/plugin/stash-sense-operations.js
+++ b/plugin/stash-sense-operations.js
@@ -223,9 +223,21 @@
       });
       progressBar.appendChild(progressFill);
       progressWrap.appendChild(progressBar);
+      const eta = getETA(job);
+      const etaText = eta ? ` \u00b7 ${eta} remaining` : '';
       progressWrap.appendChild(SS.createElement('span', {
         className: 'ss-ops-progress-text',
-        textContent: `${job.items_processed} / ${job.items_total} (${pct}%)`,
+        textContent: `${job.items_processed} / ${job.items_total} (${pct}%)${etaText}`,
+      }));
+      card.appendChild(progressWrap);
+    } else if (isActive && job.status === 'running') {
+      // Indeterminate state: running but no items_total yet
+      const progressWrap = SS.createElement('div', { className: 'ss-progress-wrap' });
+      const progressBar = SS.createElement('div', { className: 'ss-progress-bar ss-ops-progress-bar ss-progress-indeterminate' });
+      progressWrap.appendChild(progressBar);
+      progressWrap.appendChild(SS.createElement('span', {
+        className: 'ss-ops-progress-text',
+        textContent: 'Analyzing\u2026',
       }));
       card.appendChild(progressWrap);
     }
@@ -371,6 +383,22 @@
     if (secs < 60) return `${secs}s`;
     if (secs < 3600) return `${Math.floor(secs / 60)}m ${secs % 60}s`;
     return `${Math.floor(secs / 3600)}h ${Math.floor((secs % 3600) / 60)}m`;
+  }
+
+  function formatDuration(secs) {
+    if (secs < 60) return `${Math.ceil(secs)}s`;
+    if (secs < 3600) return `~${Math.ceil(secs / 60)}m`;
+    return `~${Math.floor(secs / 3600)}h ${Math.ceil((secs % 3600) / 60)}m`;
+  }
+
+  function getETA(job) {
+    if (!job.started_at || !job.items_total || !job.items_processed || job.items_processed <= 0) return null;
+    const start = new Date(job.started_at + 'Z');
+    const elapsed = (new Date() - start) / 1000;
+    if (elapsed < 3) return null;  // Too early for meaningful estimate
+    const rate = job.items_processed / elapsed;
+    const remaining = job.items_total - job.items_processed;
+    return formatDuration(remaining / rate);
   }
 
   // ==================== Polling ====================

--- a/plugin/stash-sense.css
+++ b/plugin/stash-sense.css
@@ -3174,6 +3174,27 @@ a.ss-upstream-endpoint-badge:hover {
   white-space: nowrap;
 }
 
+.ss-progress-indeterminate {
+  position: relative;
+  overflow: hidden;
+}
+
+.ss-progress-indeterminate::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -50%;
+  width: 50%;
+  height: 100%;
+  background: linear-gradient(90deg, transparent, var(--bs-primary, #0d6efd), transparent);
+  animation: ss-shimmer 1.5s ease-in-out infinite;
+}
+
+@keyframes ss-shimmer {
+  0% { left: -50%; }
+  100% { left: 100%; }
+}
+
 /* Collapsible Header */
 .ss-collapsible-header {
   cursor: pointer;


### PR DESCRIPTION
## Summary

- **Root cause**: `AnalysisJob` passed `run_id=None` to all analyzers. SQLite NULL semantics (`NULL = NULL` is falsy) meant every `WHERE run_id = ?` query matched nothing — candidates inserted with NULL but could never be queried back. The analyzer saw 0 candidates and exited immediately.
- Creates a real `analysis_runs` entry and passes the ID to the analyzer
- Adds progress callback bridge from `BaseAnalyzer` → job queue for frontend polling
- Adds stop signal support (`request_stop`/`is_stop_requested`) to `BaseAnalyzer`
- Cleans up orphaned NULL-run_id candidates on startup and before new generation
- Fixes broken `report_progress` call (was passing `items_processed` as both args)
- Adds ETA calculation and indeterminate shimmer progress bar to operations UI
- Adds periodic scoring progress logs (every 500) for Docker visibility

Fixes #87

## Test plan

- [x] All 1,065 existing tests pass (0 regressions)
- [x] 10 new tests covering run_id wiring, orphan cleanup, and progress bridge
- [ ] Start sidecar and verify startup logs show orphan cleanup
- [ ] Trigger duplicate scene detection from Operations tab
- [ ] Verify progress bar shows indeterminate state initially, then fills with ETA
- [ ] Check Docker logs for periodic progress output

🤖 Generated with [Claude Code](https://claude.com/claude-code)