### PR TITLE
Fix database download on fresh install

### DIFF
--- a/api/database_health_router.py
+++ b/api/database_health_router.py
@@ -68,7 +68,7 @@ class HealthResponse(BaseModel):
 
 
 class CheckUpdateResponse(BaseModel):
-    current_version: str
+    current_version: Optional[str] = None
     latest_version: Optional[str] = None
     update_available: bool
     release_name: Optional[str] = None

--- a/api/database_updater.py
+++ b/api/database_updater.py
@@ -184,7 +184,7 @@ class DatabaseUpdater:
                     download_size_mb = round(size_bytes / 1_000_000)
                 break
 
-        update_available = current is not None and latest_tag > current
+        update_available = current is None or latest_tag > current
 
         result: dict[str, Any] = {
             "update_available": update_available,

--- a/api/tests/test_database_updater.py
+++ b/api/tests/test_database_updater.py
@@ -162,6 +162,30 @@ class TestCheckUpdate:
         assert result["current_version"] == "2026.02.15"
         assert result["latest_version"] == "2026.02.15"
 
+    async def test_fresh_install_no_manifest(self, tmp_path):
+        """On fresh install (no manifest), update should be available."""
+        updater = DatabaseUpdater(data_dir=tmp_path, reload_fn=MagicMock(return_value=True))
+
+        release_json = _github_release_json(tag="2026.02.15")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = release_json
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("database_updater.httpx.AsyncClient") as MockClient:
+            client_instance = AsyncMock()
+            client_instance.get.return_value = mock_response
+            MockClient.return_value.__aenter__ = AsyncMock(return_value=client_instance)
+            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await updater.check_update()
+
+        assert result["update_available"] is True
+        assert result["current_version"] is None
+        assert result["latest_version"] == "2026.02.15"
+        assert result["download_url"] == "https://github.com/fake/download.zip"
+
     async def test_cache_prevents_repeated_api_calls(self, tmp_path):
         _write_manifest(tmp_path, version="2026.02.12")
         updater = DatabaseUpdater(data_dir=tmp_path, reload_fn=MagicMock(return_value=True))


### PR DESCRIPTION
## Summary
- Fix 500 error on `/database/check-update` when no database has been downloaded yet
- Allow fresh installs to download the database (previously blocked by "Already on latest version")

## Notes
Two bugs in the database update flow prevented new users from downloading the face recognition database:

1. `CheckUpdateResponse.current_version` was a required `str` field, but returns `None` on fresh installs (no `manifest.json`) — caused a Pydantic validation error → HTTP 500
2. `update_available` logic required `current_version is not None`, so even after fixing the 500, the update endpoint would reject the request with "Already on latest version"

Closes #92