### PR TITLE
Show title, studio, and performers on duplicate scene cards

### DIFF
--- a/api/analyzers/duplicate_scenes.py
+++ b/api/analyzers/duplicate_scenes.py
@@ -319,6 +319,8 @@ class DuplicateScenesAnalyzer(BaseAnalyzer):
                             "confidence": match.confidence,
                             "reasoning": match.reasoning,
                             "signal_breakdown": asdict(match.signal_breakdown),
+                            "scene_a_summary": scene_a.to_summary(),
+                            "scene_b_summary": scene_b.to_summary(),
                         },
                         confidence=match.confidence / 100.0,
                     )

--- a/api/duplicate_detection/models.py
+++ b/api/duplicate_detection/models.py
@@ -43,15 +43,19 @@ class SceneMetadata:
     studio_id: Optional[str] = None
     studio_name: Optional[str] = None
     performer_ids: set[str] = field(default_factory=set)
+    performer_names: list[str] = field(default_factory=list)
     duration_seconds: Optional[float] = None
+    file_path: Optional[str] = None
     stash_ids: list[StashID] = field(default_factory=list)
 
     @classmethod
     def from_stash(cls, data: dict) -> "SceneMetadata":
         """Create from Stash GraphQL response."""
         performer_ids = set()
+        performer_names = []
         if data.get("performers"):
             performer_ids = {p["id"] for p in data["performers"]}
+            performer_names = [p["name"] for p in data["performers"] if p.get("name")]
 
         stash_ids = []
         if data.get("stash_ids"):
@@ -61,8 +65,10 @@ class SceneMetadata:
             ]
 
         duration = None
+        file_path = None
         if data.get("files") and len(data["files"]) > 0:
             duration = data["files"][0].get("duration")
+            file_path = data["files"][0].get("path")
 
         studio_id = None
         studio_name = None
@@ -77,9 +83,21 @@ class SceneMetadata:
             studio_id=studio_id,
             studio_name=studio_name,
             performer_ids=performer_ids,
+            performer_names=performer_names,
             duration_seconds=duration,
+            file_path=file_path,
             stash_ids=stash_ids,
         )
+
+    def to_summary(self) -> dict:
+        """Return a compact dict for embedding in recommendation details."""
+        return {
+            "title": self.title,
+            "studio": self.studio_name,
+            "performers": self.performer_names,
+            "path": self.file_path,
+            "duration": self.duration_seconds,
+        }
 
 
 @dataclass

--- a/api/stash_client_unified.py
+++ b/api/stash_client_unified.py
@@ -890,6 +890,7 @@ class StashClientUnified:
                 name
               }
               files {
+                path
                 duration
               }
               stash_ids {

--- a/api/tests/test_duplicate_models.py
+++ b/api/tests/test_duplicate_models.py
@@ -83,6 +83,69 @@ class TestSceneMetadata:
         assert meta.duration_seconds == 1935.5
         assert len(meta.stash_ids) == 1
 
+    def test_captures_performer_names(self):
+        from duplicate_detection.models import SceneMetadata
+
+        stash_data = {
+            "id": "123",
+            "performers": [
+                {"id": "p1", "name": "Performer One"},
+                {"id": "p2", "name": "Performer Two"},
+            ],
+        }
+
+        meta = SceneMetadata.from_stash(stash_data)
+
+        assert meta.performer_names == ["Performer One", "Performer Two"]
+
+    def test_captures_file_path(self):
+        from duplicate_detection.models import SceneMetadata
+
+        stash_data = {
+            "id": "123",
+            "files": [{"duration": 1800, "path": "/media/videos/scene.mp4"}],
+        }
+
+        meta = SceneMetadata.from_stash(stash_data)
+
+        assert meta.file_path == "/media/videos/scene.mp4"
+
+    def test_to_summary_returns_card_data(self):
+        from duplicate_detection.models import SceneMetadata
+
+        stash_data = {
+            "id": "123",
+            "title": "Amazing Scene",
+            "date": "2024-01-15",
+            "studio": {"id": "s1", "name": "Great Studio"},
+            "performers": [
+                {"id": "p1", "name": "Alice"},
+                {"id": "p2", "name": "Bob"},
+            ],
+            "files": [{"duration": 1800, "path": "/media/videos/scene.mp4"}],
+        }
+
+        meta = SceneMetadata.from_stash(stash_data)
+        summary = meta.to_summary()
+
+        assert summary["title"] == "Amazing Scene"
+        assert summary["studio"] == "Great Studio"
+        assert summary["performers"] == ["Alice", "Bob"]
+        assert summary["path"] == "/media/videos/scene.mp4"
+        assert summary["duration"] == 1800
+
+    def test_to_summary_handles_missing_fields(self):
+        from duplicate_detection.models import SceneMetadata
+
+        meta = SceneMetadata.from_stash({"id": "999"})
+        summary = meta.to_summary()
+
+        assert summary["title"] is None
+        assert summary["studio"] is None
+        assert summary["performers"] == []
+        assert summary["path"] is None
+        assert summary["duration"] is None
+
     def test_handles_missing_fields(self):
         from duplicate_detection.models import SceneMetadata
 
@@ -93,4 +156,6 @@ class TestSceneMetadata:
         assert meta.scene_id == "999"
         assert meta.studio_id is None
         assert meta.performer_ids == set()
+        assert meta.performer_names == []
+        assert meta.file_path is None
         assert meta.duration_seconds is None

--- a/plugin/stash-sense-recommendations.js
+++ b/plugin/stash-sense-recommendations.js
@@ -1112,6 +1112,15 @@
         : sb.metadata_score > 0 ? 'Metadata'
         : 'Face analysis';
 
+      const sumA = d.scene_a_summary || {};
+      const sumB = d.scene_b_summary || {};
+      const titleA = sumA.title || `Scene ${d.scene_a_id}`;
+      const titleB = sumB.title || `Scene ${d.scene_b_id}`;
+      const studio = sumA.studio || sumB.studio || '';
+      const performers = (sumA.performers || sumB.performers || []).join(', ');
+      const contextParts = [studio, performers].filter(Boolean);
+      const contextLine = contextParts.length ? contextParts.join(' · ') : `IDs: ${d.scene_a_id} / ${d.scene_b_id}`;
+
       return SS.createElement('div', {
         className: 'ss-rec-card ss-rec-dup-scenes',
         innerHTML: `
@@ -1120,11 +1129,12 @@
               <svg viewBox="0 0 24 24" width="32" height="32" fill="currentColor"><path d="M4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm16-4H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 14H8V4h12v12z"/></svg>
             </div>
             <div class="ss-rec-card-info">
-              <div class="ss-rec-card-title">Scene ${d.scene_a_id || rec.target_id} &harr; Scene ${d.scene_b_id}</div>
+              <div class="ss-rec-card-title">${SS.escapeHtml(titleA)} &harr; ${SS.escapeHtml(titleB)}</div>
               <div class="ss-rec-card-subtitle">
                 <span style="color: ${confColor}">${Math.round(conf)}% confidence</span>
                 &middot; ${primarySignal}
               </div>
+              <div class="ss-rec-card-fields">${SS.escapeHtml(contextLine)}</div>
             </div>
           </div>
         `,


### PR DESCRIPTION
## Summary
- Duplicate scene list cards now show scene titles, studio name, and performer names instead of just scene IDs
- Scene metadata is stored in recommendation details at analysis time — no extra API calls at render time

## Changes
- `SceneMetadata` model: added `performer_names`, `file_path` fields and `to_summary()` method
- Stash GraphQL query: added `path` to file fields
- Analyzer: stores `scene_a_summary` and `scene_b_summary` in recommendation details
- Plugin UI: renders title, studio, and performers in card; falls back to scene IDs for older recommendations

## Notes
Existing recommendations created before this change will still render with scene IDs (graceful fallback). Re-running duplicate scene analysis will populate the new fields.

Refs #94